### PR TITLE
fix x scaling at less than 100%

### DIFF
--- a/src/components/FlowPanel.tsx
+++ b/src/components/FlowPanel.tsx
@@ -257,7 +257,7 @@ export const FlowPanel: React.FC<Props> = ({ options, data, width, height, timeZ
   const svgViewHeight = height - timeSliderHeight;
   const svgPaddingLeft = Math.max(0, (width - svgWidth) * 0.5);
   const svgPaddingTop = Math.max(0, (svgViewHeight - svgHeight) * 0.5);
-  const svgScaleX = (svgViewWidth / svgWidth);
+  const svgScaleX = Math.max(1.0, (svgViewWidth / svgWidth));
   const svgScaleY = (svgViewHeight / svgHeight);
   const svgScale = svgAttribs.scaleDrive ? Math.min(svgScaleX, svgScaleY) * 0.9 * 100 : 100;
 


### PR DESCRIPTION
The svg x & y axis scaling behaves differently below 100%. I'm not too sure why but with the current setup, x scaling under 100% gets automatically catered for, so this change stops 'doubling' down with a second scalar on top. With this change scales under 100% in either axis work correctly. Scaling of svgs where x/y are defines as percentages also continues to work fine.