### PR TITLE
fix fill level on repeating panels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         run: docker compose down
 
       - name: Archive E2E output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: steps.check-for-e2e.outputs.has-e2e == 'true' && steps.run-e2e-tests.outcome != 'success'
         with:
           name: cypress-videos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -5,7 +5,7 @@ jobs:
   compatibilitycheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@4
       - uses: grafana/plugin-actions/build-plugin@release
         # Uncomment to enable plugin signing
         # (For more info on how to generate the access policy token see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.17.4
+
+Fix Fill-Level Drive on Repeating Panels
+----------------------------------------
+This fixes a bug with fill-level drives on 'repeating grafana panels'. Before the fill-level from one
+panel drove the fill-level on all the repeats. With the fix they are now independent.
+
 ## 1.17.3
 
 Fix url links variable substitution
@@ -9,8 +16,8 @@ to the reserved names (cell.name and cell.dataRef).
 
 ## 1.17.2
 
-FillColor drive filter to support shapes with forground detail
---------------------------------------------------------------
+FillColor drive filter to support shapes with foreground detail
+---------------------------------------------------------------
 Complex shapes represented my more than one element (path, rect, etc.) sometimes need
 fillColor to be applied to just a subset of the elements that make up the shape. The
 draw.io 'L3 switch' is one such example that's represented using two 'rect' elements and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "description": "Svg flowchart visualization",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",

--- a/provisioning/dashboards/fillLevel.json
+++ b/provisioning/dashboards/fillLevel.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 38,
+  "id": 20,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -28,8 +28,8 @@
         "uid": "grafana"
       },
       "gridPos": {
-        "h": 19,
-        "w": 8,
+        "h": 9,
+        "w": 24,
         "x": 0,
         "y": 0
       },
@@ -52,13 +52,14 @@
         "uid": "grafana"
       },
       "gridPos": {
-        "h": 19,
-        "w": 16,
-        "x": 8,
-        "y": 0
+        "h": 14,
+        "w": 12,
+        "x": 0,
+        "y": 9
       },
       "id": 14,
       "options": {
+        "animationControlEnabled": true,
         "animationsEnabled": true,
         "debuggingCtr": {
           "colorsCtr": 0,
@@ -75,6 +76,8 @@
         "testDataEnabled": true,
         "timeSliderEnabled": true
       },
+      "repeat": "repeat",
+      "repeatDirection": "h",
       "type": "andrewbmchugh-flow-panel"
     }
   ],
@@ -83,7 +86,44 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "repeat",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "pane1",
+            "value": "pane1"
+          },
+          {
+            "selected": false,
+            "text": "pane2",
+            "value": "pane2"
+          }
+        ],
+        "query": "pane1,pane2",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
   },
   "time": {
     "from": "now-12h",

--- a/src/components/Utils.tsx
+++ b/src/components/Utils.tsx
@@ -13,7 +13,7 @@ const gShapeElements: Set<string> = new Set<string>([
   'ellipse', 'circle', 'path', 'rect', 'line', 'polyline', 'polygon']
 );
 
-var gIdCallCount = 0;
+let gIdCallCount = 0;
 
 //-----------------------------------------------------------------------------
 // Centralised debug

--- a/src/components/Utils.tsx
+++ b/src/components/Utils.tsx
@@ -13,6 +13,8 @@ const gShapeElements: Set<string> = new Set<string>([
   'ellipse', 'circle', 'path', 'rect', 'line', 'polyline', 'polygon']
 );
 
+var gIdCallCount = 0;
+
 //-----------------------------------------------------------------------------
 // Centralised debug
 //------------------
@@ -36,11 +38,11 @@ export function isShapeElement(el: HTMLElement) {
 //-----------------------------------------------------------------------------
 // Cell IDs
 //-----------------
-// Used to create unique cell Ids from a given root
+// Used to create unique cell Ids from a given root. The number offset is global
+// to ensure uniqueness for clip-path urls which have a more global scope.
 export function cellIdFactory(base: string): CellIdMaker {
-  let callCount = 0;
   return function() {
-    return base + (callCount++).toString();
+    return base + (gIdCallCount++).toString();
   }
 }
 

--- a/src/test/Utils.test.tsx
+++ b/src/test/Utils.test.tsx
@@ -16,11 +16,11 @@ test('cellIdFactory', () => {
     expect(cellIdFn()).toEqual('myid_abcd_1');
     expect(cellIdFn()).toEqual('myid_abcd_2');
 
-    const cellIdFn2 = cellIdFactory('myid_abcd_');
+    const cellIdFn2 = cellIdFactory('myid2_abcd_');
     expect(cellIdFn()).toEqual('myid_abcd_3');
-    expect(cellIdFn2()).toEqual('myid_abcd_0');
-    expect(cellIdFn2()).toEqual('myid_abcd_1');
-    expect(cellIdFn()).toEqual('myid_abcd_4');
+    expect(cellIdFn2()).toEqual('myid2_abcd_4');
+    expect(cellIdFn2()).toEqual('myid2_abcd_5');
+    expect(cellIdFn()).toEqual('myid_abcd_6');
 });
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
The clip-path url used for controlling fill level has a somewhat global scope. By using a global id counter the repeating panel clip path id becomes globally unique.