### PR TITLE
Blink element

### DIFF
--- a/provisioning/dashboards/blinkingColorsThresholgs.json
+++ b/provisioning/dashboards/blinkingColorsThresholgs.json
@@ -1,0 +1,100 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 27,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 14,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "animationControlEnabled": true,
+        "animationsEnabled": true,
+        "debuggingCtr": {
+          "colorsCtr": 0,
+          "dataCtr": 0,
+          "displaySvgCtr": 0,
+          "mappingsCtr": 0,
+          "timingsCtr": 0
+        },
+        "highlighterEnabled": true,
+        "highlighterSelection": "",
+        "panZoomEnabled": true,
+        "panelConfig": "---\n\n#------------------------------------------------------------------------------\n# YAML Aliases to simplify maintenance\n\nanchorLinks:\n  - link: &grafana-home\n      url: \"https://grafana.com/\"\n      params: \"time\"\n  - threshold_three_status: &threshold_three_status\n        - {color: \"green\", level: 0}\n        - color: \"orange\"\n          level: 500\n          blinkColor: \"yellow\"\n        - color: \"red\"\n          level: 800\n          blinkColor: \"white\"\n\n#------------------------------------------------------------------------------\n# Panel Config\n\ncellIdPreamble: \"cell-\"\ncells: \n  box1:\n    dataRef: \"test-data-large-sin\"\n    label:\n      separator: \"cr\"\n      units: \"none\"\n      decimalPoints: 0\n    labelColor:\n      gradientMode: \"normal\"\n      thresholds: *threshold_three_status\n      blinkDurationSecs: 1\n\n    # fillColor:\n    #   gradientMode: \"normal\"\n    #   thresholds: *threshold_three_status\n    #   blinkDurationSecs: 1.5\n\n    # link: *grafana-home\n    # strokeColor:\n    #   thresholds: *threshold_three_status\n    #   blinkDurationSecs: 0.8\n\n  box-3:\n    dataRef: \"test-data-large-sin\"\n    fillColor:\n      gradientMode: \"normal\"\n      thresholds: *threshold_three_status\n      blinkDurationSecs: 1\n\n  box-5:\n    dataRef: \"test-data-large-sin\"\n    strokeColor:\n      thresholds: *threshold_three_status\n      blinkDurationSecs: 0.8\n    fillColor:\n      gradientMode: \"normal\"\n      thresholds: *threshold_three_status",
+        "siteConfig": "- myvars:\n  dummy: dummy2",
+        "svg": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<svg xmlns=\"http://www.w3.org/2000/svg\" style=\"background: transparent; background-color: transparent; color-scheme: light dark;\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" width=\"513px\" height=\"81px\" viewBox=\"-0.5 -0.5 513 81\"><defs/><g><g data-cell-id=\"0\"><g data-cell-id=\"1\"><g data-cell-id=\"box1\"><g id=\"cell-box1\" content=\"&lt;UserObject label=&quot;Label&quot;/&gt;\" data-label=\"Label\"><g><rect x=\"2\" y=\"10\" width=\"120\" height=\"60\" rx=\"9\" ry=\"9\" fill=\"#ffffff\" stroke=\"#000000\" stroke-width=\"4\" pointer-events=\"all\" style=\"fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));\"/></g><g><g><switch><foreignObject style=\"overflow: visible; text-align: left;\" pointer-events=\"none\" width=\"100%\" height=\"100%\" requiredFeatures=\"http://www.w3.org/TR/SVG11/feature#Extensibility\"><div xmlns=\"http://www.w3.org/1999/xhtml\" style=\"display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 40px; margin-left: 3px;\"><div style=\"box-sizing: border-box; font-size: 0; text-align: center; color: #000000; \"><div style=\"display: inline-block; font-size: 12px; font-family: Helvetica; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; \">Label</div></div></div></foreignObject><text x=\"62\" y=\"44\" fill=\"light-dark(#000000, #ffffff)\" font-family=\"Helvetica\" font-size=\"12px\" text-anchor=\"middle\">Label</text></switch></g></g></g></g><g data-cell-id=\"box2-container\"><g id=\"cell-box2-container\" content=\"&lt;object label=&quot;&quot; tooltip=&quot;box-2-container-tooltip&quot;/&gt;\" data-label=\"\" data-tooltip=\"box-2-container-tooltip\"><g/></g><g data-cell-id=\"box-3\"><g id=\"cell-box-3\" content=\"&lt;object label=&quot;&quot;/&gt;\" data-label=\"\"><g><ellipse cx=\"452\" cy=\"40\" rx=\"60\" ry=\"40\" fill=\"#ffffff\" stroke=\"#000000\" pointer-events=\"all\" style=\"fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));\"/></g></g></g><g data-cell-id=\"box-4\"><g id=\"cell-box-4\" content=\"&lt;UserObject label=&quot;&quot;/&gt;\" data-label=\"\"><g><path d=\"M 452 10 L 482 40 L 452 70 L 422 40 Z\" fill=\"#ffffff\" stroke=\"#000000\" stroke-miterlimit=\"10\" pointer-events=\"all\" style=\"fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));\"/></g></g></g></g><g data-cell-id=\"box-5\"><g id=\"cell-box-5\" content=\"&lt;UserObject label=&quot;Label&quot;/&gt;\" data-label=\"Label\"><g><rect x=\"202\" y=\"10\" width=\"120\" height=\"60\" rx=\"9\" ry=\"9\" fill=\"#ffffff\" stroke=\"#000000\" stroke-width=\"4\" pointer-events=\"all\" style=\"fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));\"/></g><g><g><switch><foreignObject style=\"overflow: visible; text-align: left;\" pointer-events=\"none\" width=\"100%\" height=\"100%\" requiredFeatures=\"http://www.w3.org/TR/SVG11/feature#Extensibility\"><div xmlns=\"http://www.w3.org/1999/xhtml\" style=\"display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 40px; margin-left: 203px;\"><div style=\"box-sizing: border-box; font-size: 0; text-align: center; color: #000000; \"><div style=\"display: inline-block; font-size: 12px; font-family: Helvetica; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; \">Label</div></div></div></foreignObject><text x=\"262\" y=\"44\" fill=\"light-dark(#000000, #ffffff)\" font-family=\"Helvetica\" font-size=\"12px\" text-anchor=\"middle\">Label</text></switch></g></g></g></g></g></g></g></svg>",
+        "testDataEnabled": true,
+        "timeSliderEnabled": true,
+        "timeSliderMode": "local"
+      },
+      "pluginVersion": "1.18.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Blinking Color by thresholds",
+      "type": "andrewbmchugh-flow-panel"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "test blinking colors by thresholds",
+  "uid": "479cac8c-17a3-450b-82bd-522203c93d14",
+  "version": 2
+}

--- a/src/components/Config.tsx
+++ b/src/components/Config.tsx
@@ -18,6 +18,7 @@ export type ThresholdNumber = {
   color: string;
   level: number;
   order: number;
+  blinkColor: string;
 };
 
 export type ThresholdPattern = {
@@ -25,6 +26,7 @@ export type ThresholdPattern = {
   pattern: string;
   regexp: RegExp;
   order: number;
+  blinkColor: string;
 };
 
 
@@ -78,6 +80,7 @@ export type PanelConfigCellColor = DataRefDrive & {
   thresholds: ThresholdNumber[] |undefined;
   thresholdPatternsRef: string | undefined;
   thresholdPatterns: ThresholdPattern[] | undefined;
+  blinkDurationSecs: number;
 };
 
 export type PanelConfigElementFilter = {
@@ -289,6 +292,7 @@ function panelConfigDereference(siteConfig: SiteConfig, panelConfig: PanelConfig
         color.thresholds.forEach(function(threshold, index) {
           threshold.color = resolveColor(threshold.color);
           threshold.order = typeof threshold.order === 'number' ? threshold.order : index;
+          threshold.blinkColor = resolveColor(threshold.blinkColor);
         });
       }
       if (!color.thresholdPatterns && color.thresholdPatternsRef) {
@@ -299,6 +303,7 @@ function panelConfigDereference(siteConfig: SiteConfig, panelConfig: PanelConfig
           threshold.color = resolveColor(threshold.color);
           threshold.order = typeof threshold.order === 'number' ? threshold.order : index;
           threshold.regexp = typeof threshold.pattern === 'object' ? threshold.regexp : new RegExp(threshold.pattern);
+          threshold.blinkColor = resolveColor(threshold.blinkColor);
         });
       }
       if (typeof color.datapoint === 'undefined') {

--- a/src/components/Utils.tsx
+++ b/src/components/Utils.tsx
@@ -305,6 +305,19 @@ export function getColorFromPattern(thresholds: ThresholdPattern[], value: strin
   return null;
 }
 
+export function getBlinkColorFromPattern(thresholds: ThresholdPattern[], value: string, highlight: HighlightState, highlightFactors: HighlightFactors) {
+  for (let i = 0; i < thresholds.length; i++) {
+    const threshold = thresholds[i];
+    if (value.match(threshold.regexp)) {
+      return {
+        color: colorLookup(threshold.blinkColor, highlight, highlightFactors),
+        order: threshold.order,
+      }
+    }
+  }
+  return null;
+}
+
 export function getColorFromNumber(gradientMode: ColorGradientMode | undefined, thresholds: ThresholdNumber[], value: number, highlight: HighlightState, highlightFactors: HighlightFactors) {
   let threshold = thresholds[0];
   for (let i = 1; i < thresholds.length; i++) {
@@ -335,12 +348,42 @@ export function getColorFromNumber(gradientMode: ColorGradientMode | undefined, 
   }
 }
 
+export function getBlinkColorFromNumber(gradientMode: ColorGradientMode | undefined, thresholds: ThresholdNumber[], value: number, highlight: HighlightState, highlightFactors: HighlightFactors) {
+  let threshold = thresholds[0];
+  for (let i = 1; i < thresholds.length; i++) {
+    threshold = thresholds[i];
+    if (value < threshold.level) {
+      const thresholdLwr = thresholds[i - 1];
+        // The only other mode is 'none'
+        return {
+          color: colorLookup(thresholdLwr.blinkColor, highlight, highlightFactors),
+          order: thresholdLwr.order,
+        }
+      }
+  }
+  return {
+    color: colorLookup(threshold.blinkColor, highlight, highlightFactors),
+    order: threshold.order,
+  }
+}
+
 export function getColor(cellColorData: PanelConfigCellColor, value: number | string, highlight: HighlightState, highlightFactors: HighlightFactors) {
   if (cellColorData.thresholdPatterns && cellColorData.thresholdPatterns.length > 0) {
     return getColorFromPattern(cellColorData.thresholdPatterns, value.toString(), highlight, highlightFactors);
   }
   else if ((typeof value === 'number') && cellColorData.thresholds && (cellColorData.thresholds.length > 0)) {
     return getColorFromNumber(cellColorData.gradientMode, cellColorData.thresholds, value, highlight, highlightFactors);
+  }
+  return null;
+}
+
+
+export function getBlinkColor(cellColorData: PanelConfigCellColor, value: number | string, highlight: HighlightState, highlightFactors: HighlightFactors) {
+  if (cellColorData.thresholdPatterns && cellColorData.thresholdPatterns.length > 0) {
+    return getBlinkColorFromPattern(cellColorData.thresholdPatterns, value.toString(), highlight, highlightFactors);
+  }
+  else if ((typeof value === 'number') && cellColorData.thresholds && (cellColorData.thresholds.length > 0)) {
+    return getBlinkColorFromNumber(cellColorData.gradientMode, cellColorData.thresholds, value, highlight, highlightFactors);
   }
   return null;
 }

--- a/yaml_defs/panelConfig.yaml
+++ b/yaml_defs/panelConfig.yaml
@@ -290,10 +290,12 @@ cells:
       # - longhex: i.e. 'f00000'
       # - rgb: i.e. 'rgb(255, 0, 0)
       # - hsl: i.e. 'hsl(0, 100%, 50%)'
+      #
+      # version 1.18.6: add optional attributes blinkColor; use same features than for color but for a blinking color
       thresholds:
         - {color: "green", level: 0, order: null}
-        - {color: "orange", level: 500, order: null}
-        - {color: "red", level: 1000, order: null}
+        - {color: "orange", level: 500, order: null, blinkColor: "yellow"}
+        - {color: "red", level: 1000, order: null, blinkColor: "white"}
 
       # This defines an ID to a thresholds set defined in the siteConfig. If you want to share a
       # thresholds set just within the panelConfig you should instead use a yaml anchor/alias.
@@ -323,6 +325,10 @@ cells:
       # yaml anchor/alias. The above 'thresholdPatterns' field takes precedence. Only if undefined will
       # thresholdPatternsRef be checked.
       thresholdPatternsRef: "depth"
+
+      # Version 1.18.6 onwards: add blink feature for the label: will change label color every interval 
+      # duration with normal level color to blinkColor.
+      blinkDurationSecs: 0.8
 
     # Version 1.14.0 onwards: This defines an array of 'labelColor' alongside an
     # aggregation function on how the color should be chosen from the array. If 'labelColor'
@@ -355,6 +361,8 @@ cells:
         - {color: "semi-dark-green", level: 0}
         - {color: "orange", level: 400}
         - {color: "red", level: 800}
+      # Version 1.18.6 onwards: optional blinkColor for threshold and blinkDurationSecs
+      # blinkDurationSecs: 1s
 
       # See labelColor
       thresholdsRef: "depth"
@@ -413,6 +421,9 @@ cells:
 
       # Version 1.14.0 onwards: See labelColor
       thresholdPatternsRef: "depth"
+
+      # Version 1.18.6 onwards: optional blinkColor for threshold and blinkDurationSecs
+      # blinkDurationSecs: 1s
 
     # Version 1.14.0 onwards: This defines an array of 'fillColor' alongside an
     # aggregation function on how the color should be chosen from the array. If 'fillColor'


### PR DESCRIPTION
Add blink Color by thresholds feature for, labelColor, strokeColor and fillColor:
* add blinkColor attributes in thresholds
* add blinkDurationSecs that drives if a cell blink or not.

```yaml
anchorLinks:
  - link: &grafana-home
      url: "https://grafana.com/"
      params: "time"
  - threshold_three_status: &threshold_three_status
        - {color: "green", level: 0}
        - color: "orange"
          level: 500
          blinkColor: "yellow"
        - color: "red"
          level: 800
          blinkColor: "pink"
cells: 
  box1:
    dataRef: "test-data-large-sin"
    label:
      separator: "cr"
      units: "none"
      decimalPoints: 0
    labelColor:
      gradientMode: "normal"
      thresholds: *threshold_three_status
      blinkDurationSecs: 1
```

https://github.com/user-attachments/assets/1dcaf161-beea-4cd0-a3b7-041be85de88f

