### PR TITLE
add support for svg and yaml relative urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.20.0
+
+Click Actions
+-------------
+New panel config term "clickActions" introduced. Up till now cells have been clickable
+if they have a url link defined. This change extends clickability to include
+- grafanaVariable setting. Similar to links, the values defined can contain other grafana
+  variables or the reserved names for the cellName and dateRef.
+- highlighter bar selection.
+On/Off click toggling is also supported.
+
+SVG & YAML Relative Links
+-------------------------
+URL Links to the svg and yaml files have to be absolute. However as of this version, relative
+links can be defined by including a '${document.baseURI}' preamble on the link. i.e.
+${document.baseURI}d/stuff => https::mygrafanahostname:3000/d/stuff.
+
 ## 1.19.0
 
 Tabular Data and Namespaced Data Support

--- a/src/components/FlowPanel.tsx
+++ b/src/components/FlowPanel.tsx
@@ -11,7 +11,7 @@ import { svgInit, svgUpdate, SvgHolder, SvgElementAttribs } from 'components/Svg
 import { seriesExtend, seriesInterpolate , seriesTransform } from 'components/TimeSeries';
 import { TimeSliderFactory } from 'components/TimeSlider';
 import { displayColorsInner, displayDataInner, displayMappingsInner, displaySvgInner } from 'components/DebuggingEditor';
-import { colorLookup, constructGrafanaVariables, constructUrl, flowDebug, getInstrumenter } from 'components/Utils';
+import { colorLookup, constructGrafanaVariables, constructUrl, flowDebug, getInstrumenter, subSourceDataUrlTokens } from 'components/Utils';
 import { addHook, sanitize } from 'dompurify';
 import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
 
@@ -157,9 +157,9 @@ export const FlowPanel: React.FC<Props> = ({ options, data, width, height, timeZ
     setSvgStr(undefined);
     setPanelConfig(undefined);
     setSiteConfig(undefined);
-    loadSvg(options.svg, setSvgStr, setVariableIdsSvg);
-    loadYaml(options.siteConfig, (config) => {setSiteConfig(siteConfigFactory(config))}, setVariableIdsSite);
-    loadYaml(options.panelConfig, (config) => {setPanelConfig(panelConfigFactory(config))}, setVariableIdsPanel);
+    loadSvg(subSourceDataUrlTokens(options.svg), setSvgStr, setVariableIdsSvg);
+    loadYaml(subSourceDataUrlTokens(options.siteConfig), (config) => {setSiteConfig(siteConfigFactory(config))}, setVariableIdsSite);
+    loadYaml(subSourceDataUrlTokens(options.panelConfig), (config) => {setPanelConfig(panelConfigFactory(config))}, setVariableIdsPanel);
   }, [options.svg, options.panelConfig, options.siteConfig, actDynamicUrlCtr]);
 
   //---------------------------------------------------------------------------

--- a/src/components/Utils.tsx
+++ b/src/components/Utils.tsx
@@ -59,6 +59,15 @@ export function appendUrlParams(url: string, params: string): string {
   return url + params;
 }
 
+export function subSourceDataUrlTokens(str: string) {
+  const tokenBaseURI = '${document.baseURI}';
+  str = str.trim();
+  if (str.startsWith(tokenBaseURI)) {
+      str = str.replace(tokenBaseURI, document.baseURI);
+  }
+  return str;
+}
+
 export function isUrl(str: string) {
   try {
     return Boolean(new URL(str));

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,7 +10,8 @@ export const plugin = new PanelPlugin<FlowOptions>(FlowPanel).setPanelOptions((b
   .addTextInput({
     path: 'svg',
     name: 'SVG',
-    description: `This holds the SVG element or a url to the SVG element.`,
+    description: `This holds the SVG element or an absolute url to the SVG file.
+    If a relative url is needed it can be converted into an absolute url by adding a \${document.baseURI} preamble token to the link.`,
     defaultValue: 'https://raw.githubusercontent.com/andymchugh/andrewbmchugh-flow-panel/main/examples/' + svgName,
     settings: {
       useTextarea: true,
@@ -20,7 +21,7 @@ export const plugin = new PanelPlugin<FlowOptions>(FlowPanel).setPanelOptions((b
   .addTextInput({
     path: 'panelConfig',
     name: 'Panel Config',
-    description: `YAML file containing the panel config.`,
+    description: `YAML file (or url) containing the panel config.`,
     defaultValue: 'https://raw.githubusercontent.com/andymchugh/andrewbmchugh-flow-panel/main/examples/panelConfig1.yaml',
     settings: {
       useTextarea: true,
@@ -30,7 +31,7 @@ export const plugin = new PanelPlugin<FlowOptions>(FlowPanel).setPanelOptions((b
   .addTextInput({
     path: 'siteConfig',
     name: 'Site Config',
-    description: `YAML file containing the site config.`,
+    description: `YAML file (or url) containing the site config.`,
     defaultValue: '',
     settings: {
       useTextarea: true,

--- a/src/test/Utils.test.tsx
+++ b/src/test/Utils.test.tsx
@@ -1,6 +1,7 @@
 import { GrafanaTheme2, createTheme } from '@grafana/data';
 import { appendUrlParams, cellIdFactory, colorGradient,
     colorLookup, colorStringToRgb, getInstrumenter, isUrl, regExpMatch,
+    subSourceDataUrlTokens,
     variableThresholdScalarsInit, variableThresholdScaleValue } from 'components/Utils';
 import {SvgCell } from 'components/SvgUpdater';
 import { VariableThresholdScalars } from 'components/Config';
@@ -43,6 +44,22 @@ test('isUrl', () => {
     expect(isUrl('    https://mylink'    )).toEqual(true);
     expect(isUrl('file://mylink')).toEqual(true);
     expect(isUrl('    file://mylink'    )).toEqual(true);
+});
+
+test('subSourceDataUrlTokens', () => {
+    const tests = [
+        ['abc', 'abc'],
+        [' abc ', 'abc'],
+        ['{document.baseURI}stuff/d', '{document.baseURI}stuff/d'],
+        ['${document.baseURI}stuff/d', 'http://localhost/stuff/d'],
+        [' ${document.baseURI}stuff/d', 'http://localhost/stuff/d'],
+        ['x${document.baseURI}stuff/d', 'x${document.baseURI}stuff/d'],
+        [' ${document.baseURI}stuff/d/${document.baseURI}', 'http://localhost/stuff/d/${document.baseURI}'],
+        ];
+    
+    tests.forEach(([input, expected]) => {
+        expect(subSourceDataUrlTokens(input as string)).toEqual(expected);
+    });
 });
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
supported via a baseURI token substitution. See changelog.