### PR TITLE
fixed: constants read

### DIFF
--- a/src/components/bespokeDriver.tsx
+++ b/src/components/bespokeDriver.tsx
@@ -91,12 +91,47 @@ export function bespokeDriveHandlerFactory(level: number, cellId: string, cellPr
   // Regardless of whether there are any drives, defined constants and formulas need to be
   // maintained, so at least one entry is required.
   if (level === 1) {
+
     if (dataRef) {
-      state.dataRefs.add(dataRef);
+      // build constant ref into namespace to the dataRef name
+      if( typeof(dataRef) === 'object') {
+        for (const [k, v] of Object.entries(dataRef)) {
+          const value = v as string;
+          state.constants.set(k, value);
+          state.dataRefs.add(value);
+          // only get first element
+          break;
+        }
+      } else {
+        // define implicit "currentRef" on default dataRef, so it can be used in formulas
+        state.constants.set("currentRef", dataRef);
+        state.dataRefs.add(dataRef);
+      }
     }
     config.dataRefs?.forEach((v) => {
+      if( typeof(v) === 'object') {
+        for (const [k, dRef] of Object.entries(v)) {
+          const value = dRef as string;
+          state.constants.set(k, value);
+          state.dataRefs.add(value);
+          // only get first element
+          break;
+        }
+      } else {
       state.dataRefs.add(v);
+      }
     });
+
+    try {
+      // Pull in the clients constants
+      for (const [k, v] of Object.entries(config.constants || {})) {
+        state.constants.set(k, v);
+      }
+    }
+    catch (err) {
+      flowDebug().warn('Error occurred creating bespoke constant for',  element, 'error =', err, 'config =', config);
+    }
+
     config.formulas?.forEach((v) => {
       try {
         state.formulas.push(parse(v as string));


### PR DESCRIPTION
added: dataRef & dataRefs with constants definitions format.

see #189 :

constant are not read if there is no drive definitions.

The code that read the constants definition is conditionned in a loop in the config.drive.

This PMR also includes an improvement that allows specifying constants when declaring dataRefs, which then allows the defined constants to be used in reusable formulas.

Examples:

```yaml
  cell_26:
    dataRef:
      myref: <dataname>
  
    bespoke:
      dataRefs:
        - inRef: trafic_myrouter_if_in_26
        - outRef: trafic_myrouter_if_out_26
        - speedRef: speed_myrouter_if_26
      formulas: &myformulas
        - 'in = data[inRef]'
        - 'out = data[outRef]'
        - 'speed = data[speedRef]'
        - 'trafic = max(in, out)'
    [...]
  cell_27:
    bespoke:
      dataRefs:
        - inRef: trafic_myrouter_if_in_27
        - outRef: trafic_myrouter_if_out_27
        - speedRef: speed_myrouter_if_27
      formulas: *myformulas
  ```

  that allows to use generic names in formulas directly without to set constant names for each cell.
  
  By default a constant named "**currentRef**" is defined in the namespace for each dataRef if no alias is specified.

