### PR TITLE
added: allow yaml fusion operator

### DIFF
--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -47,7 +47,7 @@ export async function loadYaml(source: (Object | string), fn: (yaml: Object) => 
   // The default maxAliasCount of 100 gets hit with more complex yaml docs.
   // We don't want to allow unlimited (-1) or even configurable as that allows people
   // to configure unreasonable dashboards. Instead we amp up the limit by 100x.
-  const yamlOptions = {maxAliasCount: 10000};
+  const yamlOptions = {maxAliasCount: 10000, merge: true};
   try {
     if (typeof source === 'object') {
       fn(source);


### PR DESCRIPTION
allow to use yaml fussion operator in definition:

```yaml

- threshold_three_status: &threshold_three_status
  - color: "green"
    level: 0
  - color: "orange"
    level: 500
  - color: "red"
    level: 800
- test_threshold: &test_threshold
    thresholds: *threshold_three_status

cells:
  box1:
    labelColor:
      gradientMode: "normal"
      <<: *test_threshold

```

This example is "simple", but feature may be of some help.
Remember that "<<" only accepts **mappings** not list !