### PR TITLE
add custom tooltips - labels & aggregations data

### DIFF
--- a/provisioning/dashboards/tooltipsSimple.json
+++ b/provisioning/dashboards/tooltipsSimple.json
@@ -1,0 +1,99 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 14,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "animationControlEnabled": true,
+        "animationsEnabled": true,
+        "debuggingCtr": {
+          "colorsCtr": 0,
+          "dataCtr": 0,
+          "displaySvgCtr": 0,
+          "mappingsCtr": 0,
+          "timingsCtr": 0
+        },
+        "highlighterEnabled": true,
+        "highlighterSelection": "",
+        "panZoomEnabled": true,
+        "panelConfig": "---\n\n#------------------------------------------------------------------------------\n# YAML Aliases to simplify maintenance\n\nanchorLinks:\n  - link: &grafana-home\n      url: \"https://grafana.com/\"\n      params: \"time\"\n  - threshold_three_status: &threshold_three_status\n        - {color: \"green\", level: 0}\n        - color: \"orange\"\n          level: 500\n        - color: \"red\"\n          level: 800\n\n#------------------------------------------------------------------------------\n# Panel Config    \n\ncellIdPreamble: \"cell-\"\ncells: \n  box1:\n    bespoke:\n      dataRefs:\n        - \"test-data-small-sin\"\n        - \"test-data-large-cos\"\n# pmr #190: constants not read if drive is not defined.\n#      constants: \n#        sinRef: test-data-small-sin\n#        cosRef: test-data-large-cos\n      formulas:\n        - 'curCos = data[\"test-data-large-cos\"]'\n        - 'curSin = data[\"test-data-large-sin\"]'\n        - 'labelSin = labels[\"test-data-small-sin\"].label1'\n        - 'strNum= \"42\"'\n        - \"num = utils.Number(strNum) + 1\"\n    dataRef: \"test-data-large-sin\"\n    bespokeDataRef: curCos\n    label: \n      separator: \"cr\"\n      units: \"none\"\n      decimalPoints: 0\n    labelColor:\n      gradientMode: \"normal\"\n      thresholds: *threshold_three_status\n    tooltips:\n      format: |-\n        <center>$labelSin</center><br>\n        <span style=\"background-color: $current.labelColor;\">value: $current.label</span><br>\n        <span>value: $sin</span><br><span>ts: $sin.ts</span>\n      elements:\n        sin:\n          label:\n            bespokeDataRef: curSin\n            units: \"none\"\n            decimalPoints: 0\n          labelColor:\n            gradientMode: \"normal\"\n            thresholds: *threshold_three_status\n        labelSin:\n          label:\n            bespokeDataRef: num\n            units: \"none\"\n  box3:\n    dataRef: \"test-data-large-sin\"\n    fillColor:\n      gradientMode: \"normal\"\n      thresholds: *threshold_three_status\n\n  box-5:\n    dataRef: \"test-data-large-sin\"\n    strokeColor:\n      thresholds: *threshold_three_status\n    fillColor:\n      gradientMode: \"normal\"\n      thresholds: *threshold_three_status\n    tooltips:\n      format: default \n\n  link_box1_box3:\n    dataRef: \"test-data-large-sin\"\n    strokeColor:\n      thresholds: *threshold_three_status\n    tooltips:\n      format: default",
+        "seriesAggregation": true,
+        "siteConfig": "- myvars:\n  dummy: dummy2",
+        "svg": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<svg xmlns=\"http://www.w3.org/2000/svg\" style=\"background: #ffffff; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); color-scheme: light dark;\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" width=\"444px\" height=\"173px\" viewBox=\"0 0 444 173\"><defs/><rect fill=\"#ffffff\" width=\"100%\" height=\"100%\" x=\"0\" y=\"0\" style=\"fill: light-dark(#ffffff, var(--ge-dark-color, #121212));\"/><g><g data-cell-id=\"0\"><g data-cell-id=\"1\"><g data-cell-id=\"link_box1_box3\"><g id=\"cell-link_box1_box3\" content=\"&lt;object label=&quot;&quot;/&gt;\" data-label=\"\"><g transform=\"translate(0.5,0.5)\"><path d=\"M 113.96 62 L 145.3 80.09 L 142 82 L 138.7 83.91 L 167.92 100.74\" fill=\"none\" stroke=\"#000000\" stroke-width=\"3\" stroke-miterlimit=\"10\" pointer-events=\"stroke\" style=\"stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));\"/><path d=\"M 173.77 104.11 L 163.73 103.52 L 167.92 100.74 L 168.22 95.72 Z\" fill=\"#000000\" stroke=\"#000000\" stroke-width=\"3\" stroke-miterlimit=\"10\" pointer-events=\"all\" style=\"fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));\"/></g></g></g><g data-cell-id=\"box1\"><g id=\"cell-box1\" content=\"&lt;UserObject label=&quot;Label&quot;/&gt;\" data-label=\"Label\"><g><rect x=\"2\" y=\"2\" width=\"120\" height=\"60\" rx=\"9\" ry=\"9\" fill=\"#ffffff\" stroke=\"#000000\" stroke-width=\"4\" pointer-events=\"all\" style=\"fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));\"/></g><g><g><switch><foreignObject style=\"overflow: visible; text-align: left;\" pointer-events=\"none\" width=\"100%\" height=\"100%\" requiredFeatures=\"http://www.w3.org/TR/SVG11/feature#Extensibility\"><div xmlns=\"http://www.w3.org/1999/xhtml\" style=\"display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 32px; margin-left: 3px;\"><div style=\"box-sizing: border-box; font-size: 0; text-align: center; color: #000000; \"><div style=\"display: inline-block; font-size: 12px; font-family: Helvetica; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; \">Label</div></div></div></foreignObject><text x=\"62\" y=\"36\" fill=\"light-dark(#000000, #ffffff)\" font-family=\"Helvetica\" font-size=\"12px\" text-anchor=\"middle\">Label</text></switch></g></g></g></g><g data-cell-id=\"box2-container\"><g id=\"cell-box2-container\" content=\"&lt;object label=&quot;&quot; tooltip=&quot;box-2-container-tooltip&quot;/&gt;\" data-label=\"\" data-tooltip=\"box-2-container-tooltip\"><g transform=\"translate(0.5,0.5)\"/></g><g data-cell-id=\"box3\"><g id=\"cell-box3\" content=\"&lt;object label=&quot;&quot;/&gt;\" data-label=\"\"><g transform=\"translate(0.5,0.5)\"><ellipse cx=\"222\" cy=\"132\" rx=\"60\" ry=\"40\" fill=\"#ffffff\" stroke=\"#000000\" pointer-events=\"all\" style=\"fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));\"/></g></g></g><g data-cell-id=\"box-4\"><g id=\"cell-box-4\" content=\"&lt;UserObject label=&quot;&quot;/&gt;\" data-label=\"\"><g transform=\"translate(0.5,0.5)\"><path d=\"M 222 102 L 252 132 L 222 162 L 192 132 Z\" fill=\"#ffffff\" stroke=\"#000000\" stroke-miterlimit=\"10\" pointer-events=\"all\" style=\"fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));\"/></g></g></g></g><g data-cell-id=\"link_box-5_box3\"><g id=\"cell-link_box-5_box3\" content=\"&lt;object label=&quot;&quot;/&gt;\" data-label=\"\"><g transform=\"translate(0.5,0.5)\"><path d=\"M 372 62 Q 372 132 288.37 132\" fill=\"none\" stroke=\"#000000\" stroke-miterlimit=\"10\" pointer-events=\"stroke\" style=\"stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));\"/><path d=\"M 283.12 132 L 290.12 128.5 L 288.37 132 L 290.12 135.5 Z\" fill=\"#000000\" stroke=\"#000000\" stroke-miterlimit=\"10\" pointer-events=\"all\" style=\"fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));\"/></g></g><g data-cell-id=\"7D0A3-F1Vh0s_1ue78YS-3\"><g id=\"cell-7D0A3-F1Vh0s_1ue78YS-3\"><g><g><switch><foreignObject style=\"overflow: visible; text-align: left;\" pointer-events=\"none\" width=\"100%\" height=\"100%\" requiredFeatures=\"http://www.w3.org/TR/SVG11/feature#Extensibility\"><div xmlns=\"http://www.w3.org/1999/xhtml\" style=\"display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 114px; margin-left: 352px;\"><div style=\"box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; \"><div style=\"display: inline-block; font-size: 11px; font-family: Helvetica; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; \">Link Label</div></div></div></foreignObject><text x=\"352\" y=\"117\" fill=\"light-dark(#000000, #ffffff)\" font-family=\"Helvetica\" font-size=\"11px\" text-anchor=\"middle\">Link Label</text></switch></g></g></g></g></g><g data-cell-id=\"box-5\"><g id=\"cell-box-5\" content=\"&lt;UserObject label=&quot;Label&quot;/&gt;\" data-label=\"Label\"><g><rect x=\"322\" y=\"2\" width=\"120\" height=\"60\" rx=\"9\" ry=\"9\" fill=\"#ffffff\" stroke=\"#000000\" stroke-width=\"4\" pointer-events=\"all\" style=\"fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));\"/></g><g><g><switch><foreignObject style=\"overflow: visible; text-align: left;\" pointer-events=\"none\" width=\"100%\" height=\"100%\" requiredFeatures=\"http://www.w3.org/TR/SVG11/feature#Extensibility\"><div xmlns=\"http://www.w3.org/1999/xhtml\" style=\"display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 32px; margin-left: 323px;\"><div style=\"box-sizing: border-box; font-size: 0; text-align: center; color: #000000; \"><div style=\"display: inline-block; font-size: 12px; font-family: Helvetica; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; \">Label</div></div></div></foreignObject><text x=\"382\" y=\"36\" fill=\"light-dark(#000000, #ffffff)\" font-family=\"Helvetica\" font-size=\"12px\" text-anchor=\"middle\">Label</text></switch></g></g></g></g></g></g></g></svg>",
+        "testDataEnabled": true,
+        "timeSliderEnabled": true,
+        "timeSliderMode": "local"
+      },
+      "pluginVersion": "1.18.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "tooltips example",
+      "type": "andrewbmchugh-flow-panel"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "test tooltips",
+  "uid": "479cac8c-17a3-450b-73ce-522203c93d14",
+  "version": 2,
+  "weekStart": ""
+}

--- a/src/components/Config.tsx
+++ b/src/components/Config.tsx
@@ -136,6 +136,20 @@ export type PanelConfigCellBespoke = {
   drives: PanelConfigCellBespokeDrive[];
 };
 
+export type PanelConfigTooltipsElement = {
+  // name: string | undefined;
+  label: PanelConfigCellLabel | undefined;
+  labelColor: PanelConfigCellColor | undefined;
+};
+
+export type PanelConfigCellTooltips = {
+  format: string | undefined;
+  // elements: PanelConfigTooltipsElement[] | undefined;
+  elements: Map<string, PanelConfigTooltipsElement>;
+  content: string | undefined;
+  newElements: Map<string, PanelConfigTooltipsElement>;
+};
+
 export type PanelConfigCell = DataRefDrive & {
   linkRef: string | undefined;
   link: Link | undefined;
@@ -152,6 +166,7 @@ export type PanelConfigCell = DataRefDrive & {
   flowAnimation: PanelConfigCellFlowAnimation | undefined;
   bespoke: PanelConfigCellBespoke | undefined;
   tags: Set<string> | undefined;
+  tooltips: PanelConfigCellTooltips | undefined;
 };
 
 export type HighlightFactors = {
@@ -431,6 +446,43 @@ function panelConfigDereference(siteConfig: SiteConfig, panelConfig: PanelConfig
     if (cell.bespoke) {
       cell.bespoke.datapoint = cell.bespoke.datapoint || cell.datapoint;
     }
+
+    // cell tooltips
+    if (cell.tooltips && cell.tooltips.elements) {
+      let elements = new Map<string, PanelConfigTooltipsElement>();
+      for ( const [name, element] of Object.entries(cell.tooltips.elements)) {
+      // cell.tooltips.elements.forEach( (element: PanelConfigTooltipsElement) => {
+        if (element.label) {
+          if (typeof element.label.decimalPoints === 'undefined') {
+            element.label.decimalPoints = panelConfig.cellLabelDecimalPoints;
+          }
+          if (typeof element.label.datapoint === 'undefined') {
+            element.label.datapoint = cell.datapoint;
+          }
+          if (!element.label.valueMappings && element.label.valueMappingsRef) {
+            element.label.valueMappings = siteConfig.valueMappings.get(element.label.valueMappingsRef);
+          }
+          if (element.label.valueMappings) {
+            for (let mapping of element.label.valueMappings) {
+              mapping.valid = mapping.valid || (
+                (typeof mapping.text === 'string') &&
+                ((typeof mapping.valueMin === 'number') || (typeof mapping.valueMin === 'undefined')) &&
+                ((typeof mapping.valueMax === 'number') || (typeof mapping.valueMax === 'undefined')));
+
+              if (mapping.valid && (typeof mapping.variableSubst === 'undefined')) {
+                let interpolations: VariableInterpolation[] = [];
+                getTemplateSrv().replace(mapping.text, undefined, undefined, interpolations);
+                mapping.variableSubst = interpolations.length > 0;
+              }
+            }
+          }
+        }
+        // console.log("panelConfigDereference(): init tooltip elements for cell name:", name, "element:", element)
+        elements.set(name, element)
+      }
+      cell.tooltips.newElements = elements;
+    }
+
   });
 
   // Blend linkVariables

--- a/src/components/FlowPanel.tsx
+++ b/src/components/FlowPanel.tsx
@@ -1,17 +1,19 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { css, cx } from '@emotion/css';
 import { Button, useStyles2, useTheme2 } from '@grafana/ui';
 import { getTemplateSrv, locationService } from '@grafana/runtime';
-import { GrafanaTheme2, PanelProps, toDataFrame } from '@grafana/data';
+import { GrafanaTheme2, PanelProps } from '@grafana/data';
 import { FlowOptions, DebuggingCtrs } from '../types';
 import { configInit, panelConfigFactory, PanelConfig, siteConfigFactory, SiteConfig } from 'components/Config';
 import { HighlightState, HighlighterFactory, highlighterState } from 'components/Highlighter';
 import { loadSvg, loadYaml } from 'components/Loader';
-import { svgInit, svgUpdate, SvgHolder, SvgElementAttribs } from 'components/SvgUpdater';
-import { seriesExtend, seriesInterpolate , seriesTransform } from 'components/TimeSeries';
+import { svgInit, svgUpdate, SvgHolder, SvgElementAttribs, SvgAttribs } from 'components/SvgUpdater';
+import { seriesExtend, seriesInterpolate , seriesTransform, computeAndAttachSeriesStats } from 'components/TimeSeries';
 import { TimeSliderFactory } from 'components/TimeSlider';
 import { displayColorsInner, displayDataInner, displayMappingsInner, displaySvgInner } from 'components/DebuggingEditor';
 import { colorLookup, constructGrafanaVariables, constructUrl, flowDebug, getInstrumenter, subSourceDataUrlTokens } from 'components/Utils';
+import { TooltipTrigger, TooltipTriggerHandle, TooltipTriggerConfig } from "components/TooltipTrigger"
 import { addHook, sanitize } from 'dompurify';
 import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
 
@@ -118,6 +120,69 @@ function clickHandlerFactory(elementAttribs: Map<string, SvgElementAttribs>, lin
   }
 }
 
+function tooltipHandlerFactory(
+  svgAttribs: SvgAttribs,
+  setTooltipContent: React.Dispatch<React.SetStateAction<string | React.JSX.Element>> | null, 
+  setTooltipConfig: React.Dispatch<React.SetStateAction<TooltipTriggerConfig>> | null,
+  tooltipElementIdRef: React.MutableRefObject<string|null>,
+  setTooltipOpen: React.Dispatch<React.SetStateAction<boolean>> | null,
+  tooltipTrigger: TooltipTriggerHandle | null,
+) {
+  let activeElement: HTMLElement | null = null;
+
+  return (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    if (!tooltipElementIdRef || !setTooltipConfig || !setTooltipOpen) {
+      return;
+    }
+    if (event.target) {
+      if (event.type === "mousemove") {
+         if (!activeElement) {
+           return;
+         } else {
+
+          tooltipTrigger?.setMousePosition(event.clientX, event.clientY);
+
+          tooltipElementIdRef.current = activeElement.id;
+          // console.log('tooltipHandlerFactory(): config:', config)
+         }
+      } else {
+        const element = event.target as HTMLElement;
+        const attribs = svgAttribs.elementAttribs.get(element.id);
+        if (!attribs) {
+          return;
+        }
+        // console.log("tooltipHandlerFactory(): tooltipConfig:", tooltipConfig, " - tooltipContent:", tooltipContentRef.current)
+        const cell  = svgAttribs.cells.get(attribs.name);
+        if (cell && cell.cellProps.tooltips) {
+          const cellElement = document.getElementById(cell.cellId)
+          if (cellElement === null) { return; }
+          if (event.type === 'mouseover' ) {
+            if (activeElement === null) {
+              activeElement = cellElement
+            }
+            else if (cellElement.id === activeElement.id) {
+              return;
+            }
+            // console.log("tooltipHandlerFactory(): tooltipConfig:", tooltipConfig, " - tooltipContent:", tooltipContentRef.current)
+
+            if (setTooltipContent !== null && cell.cellIdShort !== tooltipElementIdRef.current) {
+              setTooltipContent(cell.tooltip.tooltipContent)
+            }
+            tooltipTrigger?.setMousePosition(event.clientX, event.clientY);
+            // console.log('tooltipHandlerFactory: mouseover :' + cell.cellIdShort, cell);
+            // event.stopPropagation();
+          }
+          else if(event.type === 'mouseout') {
+            if ( !cellElement?.contains(event.relatedTarget as HTMLElement) ) { 
+              setTooltipOpen(false);
+              activeElement = null;
+            }
+          }
+        }
+      }
+    }
+  }
+}
 
 export const FlowPanel: React.FC<Props> = ({ options, data, width, height, timeZone, eventBus }) => {
   //---------------------------------------------------------------------------
@@ -134,9 +199,42 @@ export const FlowPanel: React.FC<Props> = ({ options, data, width, height, timeZ
   const debuggingCtrRef = useRef<DebuggingCtrs>({...options.debuggingCtr});
   const svgHolderRef = useRef<SvgHolder>();
   const clickHandlerRef = useRef<any>(null);
+  const mouseOverHandlerRef = useRef<any>(null);
   const svgDocBlankRef = useRef<Document>(new DOMParser().parseFromString('<svg/>', "text/xml"));
   const grafanaTheme = useRef<GrafanaTheme2>(useTheme2());
   const clickCellNameLast = useRef<string | undefined>();
+
+  //---------------------------------------------------------------------------
+  // TooltipTrigger
+
+  const setTooltipContentRef = useRef<React.Dispatch<React.SetStateAction<string | React.JSX.Element>> | null>(null);
+  const registerSetterSetTooltipContent = useCallback( (setter: React.Dispatch<React.SetStateAction<string | React.JSX.Element>>) => {
+    setTooltipContentRef.current = setter;
+  }, [] );
+  const tooltipContentRef = useRef<React.JSX.Element | string >("");
+  const setTooltipOpenRef = useRef<React.Dispatch<React.SetStateAction<boolean>> | null>(null);
+  const registerSetterSetTooltipOpen = useCallback( (setter: React.Dispatch<React.SetStateAction<boolean>>) => {
+    setTooltipOpenRef.current = setter;
+  }, [] );
+
+  const setTooltipConfigRef = useRef<React.Dispatch<React.SetStateAction<TooltipTriggerConfig>> | null>(null);
+  const registerSetterSetTooltipConfig = useCallback( (setter: React.Dispatch<React.SetStateAction<TooltipTriggerConfig>>) => {
+    setTooltipConfigRef.current = setter;
+  }, [] );
+  const tooltipElementIdRef = useRef<string>("");
+  // const tooltipContainerRef = useRef<HTMLDivElement | null>(null);
+  const tooltipTriggerRef = useRef<TooltipTriggerHandle>(null);
+  useEffect(()=> {
+    if (tooltipTriggerRef.current) {
+      // tooltipTriggerRef.current.setContainerDim(0,0);
+      tooltipContentRef.current = tooltipTriggerRef.current.getTooltipContentRef();
+      // tooltipConfigRef.current = tooltipTriggerRef.current.getTooltipConfigRef();
+      // console.log("useEffect(/tooltipTriggerRef): tooltipContentRef", tooltipContentRef);
+      // tooltipContainerRef.current = tooltipTriggerRef.current.getTooltipRef();
+    }
+  }, [tooltipTriggerRef.current])
+
+  const tooltipOverlayRef = useRef<HTMLDivElement | null>(null);
 
   //---------------------------------------------------------------------------
   // Dynamic URL Terms: If we load from url we record any variable substitutions
@@ -180,7 +278,15 @@ export const FlowPanel: React.FC<Props> = ({ options, data, width, height, timeZ
   }
 
   //---------------------------------------------------------------------------
-  // Initialise DOM and config
+  // Initialize DOM and config
+
+  useEffect( () => {
+    if (tooltipOverlayRef.current) {
+      const overlayRect = tooltipOverlayRef.current?.getBoundingClientRect() ?? new DOMRect(0, 0, 0, 0);
+      // console.log('FlowPanel.useEffect(/tooltipOverlayRef): container rect:', overlayRect);
+      tooltipTriggerRef.current?.setOverlayRect(overlayRect);
+    }
+  }, [tooltipOverlayRef.current])
 
   useEffect(() => {
     if (svgStr && panelConfig && siteConfig) {
@@ -199,9 +305,19 @@ export const FlowPanel: React.FC<Props> = ({ options, data, width, height, timeZ
       clickHandlerRef.current = clickHandlerFactory(svgAttribs.elementAttribs, panelConfig.linkVariables, driveHighlighter, clickCellNameLast);
 
       driveHighlighter(options.highlighterSelection);
+      mouseOverHandlerRef.current = tooltipHandlerFactory(
+        svgAttribs,
+        setTooltipContentRef.current,
+        setTooltipConfigRef.current,
+        tooltipElementIdRef,
+        setTooltipOpenRef.current,
+        tooltipTriggerRef.current,
+      );
+      setHighlighterSelection(highlighterState(options.highlighterSelection, panelConfig.highlighter));
       setInitialized(true);
     }
   }, [initialized, svgStr, panelConfig, siteConfig, options.highlighterSelection]);
+  
   
   //---------------------------------------------------------------------------
   // Interpolate time-series data
@@ -213,8 +329,10 @@ export const FlowPanel: React.FC<Props> = ({ options, data, width, height, timeZ
   const timeMin = Number(templateSrv.replace("${__from}"));
   const timeMax = Number(templateSrv.replace("${__to}"));
 
-  const dataConverter = function(arr: any[]) { return arr.map((item: any) => toDataFrame(item)) };
-  const dataFrames = instrument('toDataFrame', dataConverter)(data.series || []);
+  const dataFrames = data.series || [];
+  if ( options.seriesAggregation ) {
+    instrument('seriesAggregation', computeAndAttachSeriesStats)(dataFrames);
+  }
   let tsData = instrument('transform', seriesTransform)(dataFrames, timeMin, timeMax, panelConfig?.dataRefTransform);
 
   if (options.testDataEnabled) {
@@ -222,6 +340,7 @@ export const FlowPanel: React.FC<Props> = ({ options, data, width, height, timeZ
   }
   
   instrument('seriesInterpolate', seriesInterpolate)(tsData, timeSliderScalarRef.current);
+
 
   //---------------------------------------------------------------------------
   // Update the SVG Attributes with the interpolated time-series data 
@@ -242,7 +361,15 @@ export const FlowPanel: React.FC<Props> = ({ options, data, width, height, timeZ
     });
   
     // Update the svg with current time-series and variable settings
-    instrument('svgUpdate', svgUpdate)(svgHolder, tsData, highlighterSelection, animationsEnabled);
+    instrument('svgUpdate', svgUpdate)(
+      svgHolder,
+      tsData,
+      highlighterSelection,
+      animationsEnabled,
+      setTooltipContentRef.current,
+      tooltipContentRef,
+      tooltipElementIdRef,
+    );
   }
   const svgElement = (svgHolder ? svgHolder.doc : svgDocBlankRef.current).childNodes[0] as HTMLElement;
 
@@ -388,13 +515,16 @@ export const FlowPanel: React.FC<Props> = ({ options, data, width, height, timeZ
   // Create the JSX
 
   const jsx = instrument('createJsx', () => (
-    <div>
+    <div style={{ position: "relative", width, height }}>
       <TransformWrapper
         disabled={!options.panZoomEnabled}
         doubleClick={{mode: "reset"}}
-        wheel={{activationKeys: panelConfig?.zoomPanPinch.wheelActivationKeys || []}}>
+        wheel={{activationKeys: panelConfig?.zoomPanPinch.wheelActivationKeys || []}}
+      >
         <TransformComponent>
-          <div className={cx(
+          <div 
+            ref={tooltipOverlayRef}
+            className={cx(
             styles.wrapper,
             css`
             height: ${svgViewHeight}px;
@@ -414,18 +544,35 @@ export const FlowPanel: React.FC<Props> = ({ options, data, width, height, timeZ
               `
               )}
               onClick={clickHandlerRef.current}
+              onMouseOver={mouseOverHandlerRef.current}
+              onMouseOut={mouseOverHandlerRef.current}
+              onMouseMove={mouseOverHandlerRef.current}
               // The externally received svg is sanitized when read in via sanitizeSvgStr which uses
               // dompurify. We don't re-sanitize it on each rendering as we are in control of the
               // modifications being made.
               dangerouslySetInnerHTML={{__html: svgElement.outerHTML}}/>
           </div>
         </TransformComponent>
+
       </TransformWrapper>
       {firstSeparator ? <hr/> : undefined}
       <div>{highlighterEnabled && highlighter}</div>
       {secondSeparator ? <hr/> : undefined}
       <div>{timeSliderEnabled && timeSlider}</div>
       {animationControlOwn ? animationControl : undefined}
+      { tooltipOverlayRef.current && 
+        createPortal(
+          <TooltipTrigger
+            ref={tooltipTriggerRef}
+            content=""
+            config={{x:0, y:0, maxWidth: width, maxHeight: height,}}
+            open={false}
+            registerSetterSetTooltipContent={registerSetterSetTooltipContent}
+            registerSetterSetTooltipOpen={registerSetterSetTooltipOpen}
+            registerSetterSetTooltipConfig={registerSetterSetTooltipConfig}
+          />,
+          tooltipOverlayRef.current
+        )}
     </div>
   ))();
   return jsx;

--- a/src/components/SvgUpdater.tsx
+++ b/src/components/SvgUpdater.tsx
@@ -7,7 +7,7 @@ import {
   PanelConfig, PanelConfigCell, PanelConfigCellColor,
   PanelConfigCellColorCompound,
   PanelConfigCellFillLevel, PanelConfigCellFlowAnimation, PanelConfigCellLabel,
-  PanelConfigElementFilter,
+  PanelConfigElementFilter, PanelConfigTooltipsElement,
   SiteConfig, VariableThresholdScalars } from 'components/Config';
 import { TimeSeriesData } from 'components/TimeSeries';
 import {
@@ -19,6 +19,30 @@ import {
   CellFillLevelDriver, getClipper, isFillLevelElement } from 'components/FillLevel';
 import { getTemplateSrv } from '@grafana/runtime';
 import { attribDriverManager, bespokeDriveHandlerFactory, ScopedState, CellBespokeHandler, getBespokeData } from './bespokeDriver';
+import { sanitize } from 'dompurify';
+
+type TooltipVariableInstanceType = "label" | "labelColor" | "ts" | "default";
+
+export type TooltipVariableInstance = {
+  varName: string;
+  type: TooltipVariableInstanceType;
+  pattern?: RegExp;
+  // the "whole" string to substitute in pattern 
+  varString: string;
+}
+
+export type TooltipVar = {
+  element: PanelConfigTooltipsElement | undefined;
+  value: any;
+  color: any;
+  ts: any;
+}
+export type TooltipHolder = {
+  tooltipContent: string;
+  usedVars: Map<string, TooltipVar>;
+  // usedInstances: Map<string, TooltipVariableInstance>;
+  usedInstances: TooltipVariableInstance[];
+}
 
 // Defines the metadata stored against each drivable svg cell
 export type SvgCell = {
@@ -31,6 +55,8 @@ export type SvgCell = {
   text: string;
   cellProps: PanelConfigCell;
   variableThresholdScalars: Map<string, VariableThresholdScalars[]>;
+  tooltip: TooltipHolder;
+
 };
 
 export type SvgElementAttribs = {
@@ -233,7 +259,12 @@ function recurseElements(level: number, el: HTMLElement, cellData: SvgCell, cell
   return false;
 }
 
-export function svgInit(doc: Document, grafanaTheme: GrafanaTheme2, panelConfig: PanelConfig, siteConfig: SiteConfig):  SvgAttribs {
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function svgInit(doc: Document, grafanaTheme: GrafanaTheme2, panelConfig: PanelConfig, siteConfig: SiteConfig, 
+  ):  SvgAttribs {
   let cells = new Map<string, SvgCell>();
   const cellIdPreamble = panelConfig.cellIdPreamble;
   const namespaceState = new Map<string, ScopedState>();
@@ -244,6 +275,12 @@ export function svgInit(doc: Document, grafanaTheme: GrafanaTheme2, panelConfig:
     const cellIdMaker = cellIdFactory(cellId + panelConfig.cellIdExtender);
     let el = doc.getElementById(cellId);
     if (el) {
+      const tooltip: TooltipHolder = {
+        tooltipContent: '',
+        usedVars: new Map<string, TooltipVar>(),
+        // usedInstances: new Map<string, TooltipVariableInstance>(),
+        usedInstances: [],
+      }
       const cell = {
         cellIdShort: cellIdShort,
         cellId: cellId,
@@ -254,6 +291,7 @@ export function svgInit(doc: Document, grafanaTheme: GrafanaTheme2, panelConfig:
         text: '',
         cellProps: cellProps,
         variableThresholdScalars: new Map<string, VariableThresholdScalars[]>(),
+        tooltip: tooltip,
       };
       cells.set(cellIdShort, cell);
 
@@ -268,6 +306,87 @@ export function svgInit(doc: Document, grafanaTheme: GrafanaTheme2, panelConfig:
       // Now the loop of recursions is done, add in the additional elements
       for (let addition of additions) {
         el.prepend(addition);
+      }
+
+      // if tooltip is defined, build a map for known variables set in format attributes and defined elements list
+      if (cellProps.tooltips) {
+        if (!cellProps.tooltips.format || cellProps.tooltips.format === '' || cellProps.tooltips.format === 'default') {
+          cellProps.tooltips.format = `<span style="display: block; text-align: center;">$ts</span><hr><span>value: $current</span>`;
+        }
+        let usedInstances= new Map<string, TooltipVariableInstance>();
+        for (const match of cellProps.tooltips.format.matchAll(/\$({?([a-zA-Z_]\w*)(?:\.([a-zA-Z_]\w*))?}?)/g)) {
+          // analyze var format.
+          // match[1] is the pattern that we will to substitute during render.
+          // match[2] is the variable name
+          // match[3] if defined is the attribute name from variable to used, else pattern type is default
+          
+          // if instance is already in map not necessary to prepare again!
+          if ( !usedInstances.get(match[1]) ) {
+            // build tooltips var map or remove name not found in elements
+            // check if variable name exists in element list
+            if( !tooltip.usedVars.get(match[2]) ) {
+              let element, found = false;
+              // console.log("sgvInit(): add tooltip for ", cellIdShort, "var ", match[2], "not already defined")
+              if ( ["ts", "current"].includes(match[2]) ) {
+                element = undefined;
+                found = true;
+                // console.log("sgvInit(): add tooltip for ", cellIdShort, "var ", match[2], "is internal")
+              } else if (cellProps.tooltips.newElements) {
+                element = cellProps.tooltips.newElements.get(match[2]);
+                if (element !== undefined) {
+                  // console.log("sgvInit(): add tooltip for ", cellIdShort, "var ", match[2], "found in elements.")
+                  found = true;
+                } else {
+                  // console.log("sgvInit(): add tooltip for ", cellIdShort, "var ", match[2], "not found: not in elements.")
+                }
+              } else {
+                // console.log("sgvInit(): add tooltip for ", cellIdShort, "var ", match[2], "not found: no elements defined.")
+              }
+              if (found) {
+                // console.log("sgvInit(): add tooltip for ", cellIdShort, " var:", match[2])
+                let variable: TooltipVar = {
+                  element: element,
+                  value: undefined,
+                  color: undefined,
+                  ts: undefined,
+                }
+                tooltip.usedVars.set(match[2], variable);
+              }
+            }
+
+            let instance: TooltipVariableInstance = {
+              varName: match[2],
+              type: "default",
+              pattern: undefined,
+              varString: match[1],
+            }
+            if (match[3] !== undefined) {
+              if( ["labelColor", "label", "ts"].includes(match[3]) ) {
+                instance.type = match[3] as TooltipVariableInstanceType;
+              }
+            }
+
+            // Precompute pattern (use literal escape to avoid regexp injection and special chars)
+            try {
+              instance.pattern = new RegExp(escapeRegExp('$' + match[1]), 'g');
+            } catch (e) {
+              // fallback: if for some reason invalid, still store a safe pattern matching the literal
+              instance.pattern = new RegExp('$' + match[1], 'g');
+            }
+
+            // console.log("sgvInit(): add tooltip for ", cellIdShort, " var instance type:", match[1], instance.type)
+            usedInstances.set(match[1],instance)
+          }
+        }
+        if (usedInstances.size >0) {
+          const keys = Array.from(usedInstances.keys());
+          for( const key of  keys.sort((a, b) => b.length - a.length) ) {
+            const instance = usedInstances.get(key);
+            if ( instance ) {
+              tooltip.usedInstances.push(instance)
+            }
+          }
+        }
       }
     }
   });
@@ -320,35 +439,53 @@ export function svgInit(doc: Document, grafanaTheme: GrafanaTheme2, panelConfig:
     bespokeHandlers: bespokeHandlers,
   };
 
-  // Initialie the color cache and setup the background
+  // Initialize the color cache and setup the background
   primeColorCache(grafanaTheme, svgAttribs, panelConfig.background);
 
   return svgAttribs;
 } 
 
-export function getCellValue(drive: DataRefDrive | undefined, tsData: TimeSeriesData, cellBespokeData: any) {
+export type GetCellValueType = {
+  value: string|number| any;
+  ts: number|any;
+  labels: any;
+  aggregations: any;
+}
+
+export function getCellValue(
+  drive: DataRefDrive | undefined,
+  tsData: TimeSeriesData,
+  cellBespokeData: any,
+): GetCellValueType {
   // Return bespoke value if defined
+  let value = null, retTs=null, labels=null, agg = null;
+
   if (cellBespokeData && drive?.bespokeDataRef) {
-    return cellBespokeData[drive.bespokeDataRef];
+    value = cellBespokeData[drive.bespokeDataRef]?.value
+    retTs = cellBespokeData[drive.bespokeDataRef]?.ts;
+    labels = cellBespokeData[drive.bespokeDataRef]?.labels;
+    agg = cellBespokeData[drive.bespokeDataRef]?.aggregations;
   }
-  let value = null;
-  if (drive?.dataRef) {
+  else if (drive?.dataRef) {
     const ts = tsData.ts.get(drive.dataRef);
     if (ts && (typeof ts.time.valuesIndex === 'number')) {
       value = ts.values[ts.time.valuesIndex];
-
+      retTs = ts.time.values[ts.time.valuesIndex];
+      labels = ts.labels;
+      agg = ts.aggregations;          
       // lastNotNull results in a walkback till a non null value is found
       if (drive.datapoint === 'lastNotNull') {
         for (let i = ts.time.valuesIndex; i >= 0; i--) {
           value = ts.values[i];
           if (typeof value === 'number') {
+            retTs = ts.time.values[i];
             break;
           }
         }
       }
     }
   }
-  return value;
+  return { value: value, ts: retTs, labels: labels, aggregations: agg };
 }
 
 export function valueMapping(valueMappings: FlowValueMapping[], value: number | string | null) {
@@ -468,7 +605,7 @@ function thresholdSeed(sdb: SvgDriveBase,
   defaultSeed: number | string | null,
   bespokeData: any) {
   if (paramData?.dataRef || paramData?.bespokeDataRef) {
-    const cellValue = getCellValue(paramData, sdb.tsData, bespokeData);
+    const cellValue = getCellValue(paramData, sdb.tsData, bespokeData)?.value;
     return variableThresholdScaleValue(sdb.variableValues, sdb.cellData, cellValue);
   }
   else {
@@ -503,7 +640,15 @@ function getThresholdColorCompound(sdb: SvgDriveBase,
   return compound;
 }
 
-export function svgUpdate(svgHolder: SvgHolder, tsData: TimeSeriesData, highlighterSelection: string | undefined, animationsEnabled: boolean) {
+export function svgUpdate(
+    svgHolder: SvgHolder, 
+    tsData: TimeSeriesData, 
+    highlighterSelection: string | undefined, 
+    animationsEnabled: boolean,
+    setTooltipContent: React.Dispatch<React.SetStateAction<string | React.JSX.Element>> | null,
+    tooltipContentRef: React.MutableRefObject<string>,
+    tooltipElementIdRef: React.MutableRefObject<string>,
+  ) {
   const variableValues = svgHolder.attribs.variableValues;
   const elementAttribs = svgHolder.attribs.elementAttribs;
   const highlightFactors = svgHolder.attribs.highlightFactors;
@@ -523,26 +668,28 @@ export function svgUpdate(svgHolder: SvgHolder, tsData: TimeSeriesData, highligh
     };
     const cellBespokeData = getBespokeData(cellId, cellData.cellProps, namespacedData);
     
-    const cellValue = getCellValue(cellData.cellProps, tsData, cellBespokeData);
+    const currentValue = getCellValue(cellData.cellProps, tsData, cellBespokeData)
+    const cellValue = currentValue.value;
     const cellValueSeed = variableThresholdScaleValue(variableValues, cellData, cellValue);
 
     const cellLabelData = cellData.cellProps.label;
-    const cellLabelValueInner = getCellValue(cellLabelData, tsData, cellBespokeData);
+    const currentValueInner = getCellValue(cellLabelData, tsData, cellBespokeData);
+    const cellLabelValueInner = currentValueInner.value;
     const cellLabelValue = cellLabelValueInner !== null ? cellLabelValueInner : cellValue;
     const cellLabelMappedValue = cellLabelData?.valueMappings ? valueMapping(cellLabelData.valueMappings, cellLabelValue) : null;
     const cellLabel = cellLabelMappedValue || (cellLabelData && (typeof cellLabelValue === 'number') ? formatCellValue(cellLabelData, cellLabelValue) : cellLabelValue);
 
-    const cellStrokeColor = cellData.cellProps.strokeColorCompound ?
-      getThresholdColorCompound(sdb, cellValueSeed, cellData.cellProps.strokeColorCompound, cellBespokeData) :
-      getThresholdColor(sdb, cellValueSeed, cellData.cellProps.strokeColor, cellBespokeData);
+    const cellStrokeColor = cellData.cellProps.strokeColorCompound
+      ? getThresholdColorCompound(sdb, cellValueSeed, cellData.cellProps.strokeColorCompound, cellBespokeData)
+      : getThresholdColor(sdb, cellValueSeed, cellData.cellProps.strokeColor, cellBespokeData);
 
-    const cellFillColor = cellData.cellProps.fillColorCompound ?
-      getThresholdColorCompound(sdb, cellValueSeed, cellData.cellProps.fillColorCompound, cellBespokeData) :
-      getThresholdColor(sdb, cellValueSeed, cellData.cellProps.fillColor, cellBespokeData);
+    const cellFillColor = cellData.cellProps.fillColorCompound
+      ? getThresholdColorCompound(sdb, cellValueSeed, cellData.cellProps.fillColorCompound, cellBespokeData)
+      : getThresholdColor(sdb, cellValueSeed, cellData.cellProps.fillColor, cellBespokeData);
 
-    const cellLabelColor = cellData.cellProps.labelColorCompound ?
-      getThresholdColorCompound(sdb, cellValueSeed, cellData.cellProps.labelColorCompound, cellBespokeData) :
-      getThresholdColor(sdb, cellValueSeed, cellData.cellProps.labelColor, cellBespokeData);
+    const cellLabelColor = cellData.cellProps.labelColorCompound
+      ? getThresholdColorCompound(sdb, cellValueSeed, cellData.cellProps.labelColorCompound, cellBespokeData)
+      : getThresholdColor(sdb, cellValueSeed, cellData.cellProps.labelColor, cellBespokeData);
 
     const cellFillLevelData = cellData.cellProps.fillLevel;
     const cellFillLevelSeed = thresholdSeed(sdb, cellFillLevelData, cellValueSeed, cellBespokeData);
@@ -551,14 +698,30 @@ export function svgUpdate(svgHolder: SvgHolder, tsData: TimeSeriesData, highligh
     const cellFlowAnimSeed = thresholdSeed(sdb, cellFlowAnimData, cellValueSeed, cellBespokeData);
     const cellFlowAnimState = cellFlowAnimData ? getFlowAnimationState(cellFlowAnimData, animationsEnabled ? cellFlowAnimSeed : null ) : null;
 
-    cellData.fillElements.forEach((el: HTMLElement) => {
-      if (cellData.cellProps.labelColor || cellData.cellProps.labelColorCompound) {
-        el.style.color = cellLabelColor?.color || elementAttribs.get(el.id)?.styleColor || '';
+    // Update fill elements/text elements: cache often used values locally
+    const labelValueForReplace = cellData.text + (cellLabel ?? '');
+
+    if ((cellData.cellProps.labelColor || cellData.cellProps.labelColorCompound) && cellLabelColor) {
+      // cache color string
+      const labelColorStr = cellLabelColor?.color || '';
+      for (const el of cellData.fillElements) {
+        const elAttrib = elementAttribs.get(el.id);
+
+        el.style.color = labelColorStr || elAttrib?.styleColor || '';
+        if (cellLabelData) {
+          // only replace children when value changed could be added later
+          el.replaceChildren(document.createTextNode(labelValueForReplace));
+        }
       }
-      if (cellLabelData) {
-        el.replaceChildren(cellData.text + (cellLabel || ''));
+    } else {
+      // no label color handling but still set text if required
+      for (const el of cellData.fillElements) {
+        if (cellLabelData) {
+          el.replaceChildren(document.createTextNode(labelValueForReplace));
       }
-    });
+      }
+    }
+
     if (cellData.cellProps.strokeColor || cellData.cellProps.strokeColorCompound) {
       cellData.strokeElements.forEach((el: HTMLElement) => {
         setStrokeAttribute(el, cellStrokeColor?.color, elementAttribs.get(el.id));
@@ -572,15 +735,126 @@ export function svgUpdate(svgHolder: SvgHolder, tsData: TimeSeriesData, highligh
         setFillAttribute(el, cellFillColor?.color, elementAttribs.get(el.id));
       });
     }
+
+    // fill level clipping
     if (cellFillLevelData) {
       cellData.fillClipDrivers.forEach((fillClipDriver) => {
         fillClipDriver(cellFillLevelSeed);
       });
     }
+
+    // flow animation
     if (cellFlowAnimState) {
       cellData.textElements.forEach((el: HTMLElement) => {
         setFlowAnimationAttributes(el, cellFlowAnimState);
       });
+    }
+
+    // ---- Tooltip handling (heavy, so keep it compact & safe) ----
+    if (cellData.cellProps.tooltips && cellData.cellProps.tooltips.format) {
+      // get format line end trimmed
+      let content = cellData.cellProps.tooltips.format.replace(/\s*\r?\n\s*/g, '');
+
+      // 1) update usedVars values
+      for (const [varKey, element] of cellData.tooltip.usedVars) {
+        // console.log('svgUpdate(): for ',  cellId, 'update var values key:',key, 'element:', element, "content:", content);
+        switch (varKey) {
+          case "ts":
+            const formater = getValueFormatterIndex()['dateTimeAsSystem'];
+            element.value = formater(currentValue?.ts, 0, 0, "").text;
+            break;
+          case "current":
+            element.value = cellLabel;
+            element.color = cellLabelColor?.color || null;
+            break;
+          default:
+            let cellTooltipValueSeed: any = null;
+            if(element.element?.label) {
+              const cellTooltipsData = element.element.label;
+              const cellTooltipsValueInner = getCellValue(cellTooltipsData, tsData, cellBespokeData);
+              const cellTooltipsValue = cellTooltipsValueInner?.value !== null ? cellTooltipsValueInner?.value : cellValue;
+              cellTooltipValueSeed = variableThresholdScaleValue(variableValues, cellData, cellTooltipsValue);
+              const cellTooltipsMappedValue = cellTooltipsData?.valueMappings ? valueMapping(cellTooltipsData.valueMappings, cellTooltipsValue) : null;
+              element.value = cellTooltipsMappedValue || (cellTooltipsData && (typeof cellTooltipsValue === 'number') ? formatCellValue(cellTooltipsData, cellTooltipsValue) : cellTooltipsValue);
+              const formater = getValueFormatterIndex()['dateTimeAsSystem'];
+              element.ts = formater(cellTooltipsValueInner?.ts, 0, 0, "").text;
+            }
+            if(element.element?.labelColor && cellTooltipValueSeed) {
+              element.color = getThresholdColor(sdb, cellTooltipValueSeed, element.element.labelColor, cellBespokeData)?.color || null;          }
+            break;
+        }
+      }
+
+      // 2) replace instances — ensure we treat the key as literal (escape special chars)
+      for (const instance of cellData.tooltip.usedInstances) {
+        const element = cellData.tooltip.usedVars.get(instance.varName);
+        // console.log('svgUpdate(): for ',  cellId, 'instance:', instance, 'element:', element, "content:", content);
+        if (!element) {
+          continue;
+        }
+
+        const pattern = instance.pattern ?? new RegExp(escapeRegExp(instance.varString), 'g');
+        let value: string | number | any = instance.varString;
+
+        switch (instance.type) {
+          case "label":
+            value = element.value ?? '';
+            break;
+          case "labelColor":
+            value = element.color ?? '';
+            break;
+          case "ts":
+            value = element.ts ?? '';
+            break;
+          default:
+            value = element.value ?? '';
+            if (element.color) {
+              value = `<font style="color: ${element.color};">${value}</font>`
+            }
+            break;
+        }
+        // do replacement
+        if (value !== '' && value !== instance.varString) {
+          content = content.replace(pattern, String(value))
+        }
+      }
+
+      // check change to sanitize only if necessary
+      const previousSanitized = cellData.tooltip.tooltipContent;
+      // const rawChanged = content !== previousSanitized;
+      // const tc = tooltipConfigRef?.current;
+      // console.log('svgUpdate(): for ',  cellId, //'currentId:', tc?.elementId,
+      //   'content:', content, 'prev:', previousSanitized, 'rawChanged:', content !== previousSanitized);
+      // sanitize result once
+      if (content !== previousSanitized) {
+        const sanitized = sanitize(content)
+
+        // update tooltip holder and potentially the visible tooltip
+        if ( previousSanitized !== sanitized ) {
+          cellData.tooltip.tooltipContent = sanitized;
+
+          // if( tooltipConfigRef && tooltipConfigRef.current ) {
+          //   console.log('svgUpdate(): tooltipTriggerElementId:', tooltipConfigRef.current?.elementId)
+          // } else {
+          //   console.log('svgUpdate(): tooltipTriggerElementId:null')
+          // }
+          // if( !tooltipConfigRef || !tooltipConfigRef.current ) {
+          //   console.log('svgUpdate(): tooltipContentRef.current:', tooltipContentRef.current, '- content:', content)
+          //   return;
+          // }
+          // console.log('svgUpdate(): tooltipContentRef.current:', tooltipContentRef.current, '- content:', content)
+
+          // update visible tooltip content by matching tooltipConfigRef
+          const elementId = tooltipElementIdRef?.current;
+          // console.log('svgUpdate() tooltip: cellId:', cellId, " - tooltipElementIdRef.current:", elementId, ' - tooltipContentRef.current:', tooltipContentRef.current)
+          if (elementId && cellData.cellId === elementId && tooltipContentRef.current !== sanitized) {
+            // console.log('svgUpdate: will update content for cell', cellId)
+            tooltipContentRef.current = sanitized;
+            setTooltipContent?.(content);
+          }
+        }
+        // console.log('svgUpdate: tooltip.content', sanitized)
+      }
     }
   });
 }

--- a/src/components/TimeSeries.tsx
+++ b/src/components/TimeSeries.tsx
@@ -1,4 +1,4 @@
-import { FieldType, getFieldDisplayName } from '@grafana/data';
+import { DataFrame, FieldType, getFieldDisplayName, reduceField, ReducerID } from '@grafana/data';
 import { sliderTime } from 'components/TimeSlider';
 import { DataRefTransform, DataRefTransformQuery, TestConfig } from './Config';
 
@@ -8,6 +8,8 @@ export type TimeSeries = {
     values: number[];
   }
   values: Array<number | string | null>;
+  labels: Map<string, string>;
+  aggregations: Map<string, number>;
 };
 
 export type TimeSeriesData = {
@@ -17,13 +19,23 @@ export type TimeSeriesData = {
   ts: Map<string, TimeSeries>;
 };
 
+export type SeriesStats = {
+  min?: number;
+  max?: number;
+  mean?: number;
+  last?: number;
+  lastNotNull?: number;
+  count?: number;
+};
+
+
 export function seriesExtend(tsData: TimeSeriesData, testConfig: TestConfig | undefined) {
   const timeMin = tsData.timeMin;
   const timeMax = tsData.timeMax;
   const dataSparse = testConfig?.testDataSparse;
   const dataExtendedZero = testConfig?.testDataExtendedZero;
   const baseOffset = typeof testConfig?.testDataBaseOffset === 'number' ? testConfig.testDataBaseOffset : 1;
-  const create = function(datapoints: number, scalar: number, fn: (inp: number) => number, asString: boolean) {
+  const create = function(datapoints: number, scalar: number, fn: (inp: number) => number, asString: boolean, labels: Map<string,string>| null) {
     const intervalTime = Math.ceil((timeMax - timeMin) / datapoints);
     const intervalValue = 2 * Math.PI / datapoints;
     let timeValues = [];
@@ -36,32 +48,38 @@ export function seriesExtend(tsData: TimeSeriesData, testConfig: TestConfig | un
       const val2 = asString && (typeof val1 === 'number') ? '*' + Math.ceil(val1).toString() + '*' : val1;
       dataValues.push(val2);
     }
+    if (labels === null ) {
+      labels = new Map();
+    }
+
     return {
       time: {values: timeValues},
       values: dataValues,
+      labels: labels,
+      aggregations: new Map(),
     };
   }
 
   let dataSets = [
-    {name: 'test-data-small-sin', datapoints: 75, scalar: 100, fn: Math.sin, asString: false},
-    {name: 'test-data-large-sin', datapoints: 50, scalar: 500, fn: Math.sin, asString: false},
-    {name: 'test-data-small-cos', datapoints: 60, scalar: 100, fn: Math.cos, asString: false},
-    {name: 'test-data-large-cos', datapoints: 88, scalar: 500, fn: Math.cos, asString: false},
+    {name: 'test-data-small-sin', datapoints: 75, scalar: 100, fn: Math.sin, asString: false, labels: new Map<string,string>([['label1', 'value1'], ['label2_num', '2'],]) },
+    {name: 'test-data-large-sin', datapoints: 50, scalar: 500, fn: Math.sin, asString: false, labels: null},
+    {name: 'test-data-small-cos', datapoints: 60, scalar: 100, fn: Math.cos, asString: false, labels: null},
+    {name: 'test-data-large-cos', datapoints: 88, scalar: 500, fn: Math.cos, asString: false, labels: null},
   ];
 
   if (testConfig?.testDataStringData) {
-    dataSets.push({name: 'test-data-string', datapoints: 65, scalar: 500, fn: Math.cos, asString: true});
+    dataSets.push({name: 'test-data-string', datapoints: 65, scalar: 500, fn: Math.cos, asString: true, labels: null});
   }
 
   dataSets.forEach((ds) => {
     if (!tsData.ts.get(ds.name)) {
-      tsData.ts.set(ds.name, create(ds.datapoints, ds.scalar, ds.fn, ds.asString));
+      tsData.ts.set(ds.name, create(ds.datapoints, ds.scalar, ds.fn, ds.asString, ds.labels));
     }
   });
   if (testConfig?.testDataNoTime) {
     const name = 'test-data-no-time';
     if (!tsData.ts.get(name)) {
-      tsData.ts.set(name, {values: [123], time: {values: [0], valuesIndex: null}});
+      tsData.ts.set(name, {values: [123], time: {values: [0], valuesIndex: null}, labels: new Map(), aggregations: new Map()});
     }
   }
 }
@@ -126,7 +144,33 @@ export function seriesTransform(series: any[], panelTimeMin: number, panelTimeMa
           }
           else {
             const name = applyNamespace(getFieldDisplayName(ts, frame));
-            tsNamed[name] = {values: ts.values, time: null};
+            const labels = new Map<string, string>();
+            const aggregations = new Map<string, number>();
+            if (ts.labels) {
+              for ( const [key, value] of Object.entries(ts.labels)) {
+                if ( typeof value === 'string' ) {
+                  labels.set(key,value)
+                }
+              }
+            }
+            if (ts.state) {
+              let src = undefined;
+              if (ts.state.calcs != undefined) {
+                src = ts.state.calcs
+              }
+              else if (ts.state.range != undefined ) {
+                src = ts.state.range
+              }
+              if( src != undefined ) {
+                for ( const [key, value] of Object.entries(src)) {
+                  if ( typeof value === 'number' ) {
+                    aggregations.set(key,value)
+                  }
+                }
+              }
+            }
+
+            tsNamed[name] = {values: ts.values, time: null, labels: labels, aggregations: aggregations};
           }
         });
       }
@@ -189,4 +233,33 @@ export function seriesInterpolate(tsData: TimeSeriesData, timeSliderScalar: numb
     }
   });
   return tsData;
+}
+
+export function computeAndAttachSeriesStats(
+  frames: DataFrame[]
+): SeriesStats[] {
+  return frames.map(frame => {
+    const valueField = frame.fields.find(f => f.type === FieldType.number);
+    if (!valueField) {
+      return {};
+    }
+
+    const calcs = reduceField({
+      field: valueField,
+      reducers: [
+        ReducerID.lastNotNull,
+        ReducerID.min,
+        ReducerID.max,
+        ReducerID.mean,
+      ],
+    });
+
+    valueField.state = valueField.state ?? {};
+    valueField.state.calcs = {
+      ...(valueField.state.calcs ?? {}),
+      ...calcs,
+    };
+
+    return calcs as SeriesStats;
+  });
 }

--- a/src/components/TooltipTrigger.tsx
+++ b/src/components/TooltipTrigger.tsx
@@ -1,0 +1,315 @@
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { GrafanaTheme2} from '@grafana/data';
+import { Popover, useStyles2 } from '@grafana/ui';
+import { css, cx } from '@emotion/css';
+
+
+export type TooltipTriggerConfig = {
+  x: number;
+  y: number;
+  maxWidth?: number;
+  maxHeight?: number;
+}
+
+type TooltipTriggerInternalConfig = TooltipTriggerConfig & {
+  container: { width: number, height: number};
+  overlayRect: DOMRect;
+}
+
+function getPosition(config: TooltipTriggerInternalConfig) {
+    const mouseX = config.x, mouseY = config.y;
+    let vPos = 'middle', hPos='right';
+    const paddingLeft = 20, paddingTop = 20;
+
+    // let left = (mouseX - config.overlayRect.x) ;
+    let top = mouseY - ( config.container.height / 2 );
+    let left = mouseX - ( config.container.width / 2 ) ;
+    
+    // console.log('TooltipTrigger.getPosition(): config', config, 'left:', left, 'top:', top)
+    // console.log('TooltipTrigger.getPosition(): overlay.right', config.overlayRect.right, 'container.w/2', config.container.width / 2, 'mx', mouseX, 'left:', left, 'top:', top)
+    
+    if (top < config.overlayRect.top ) {
+        vPos='top';
+    }
+    else if ( mouseY + config.container.height / 2 > config.overlayRect.bottom ) {
+        vPos= 'bottom';
+    }
+    if ( left < config.overlayRect.left ) {
+        hPos = 'right';
+    }
+    else if ( mouseX + paddingLeft + config.container.width > config.overlayRect.right ) {
+        hPos='left';
+        if (  mouseX + config.container.width / 2 < config.overlayRect.right ) {
+            hPos = 'middle';
+            // have to force popup above(bottom) or below (top) the cursor; choose below by default
+            vPos = 'top';
+            if (top < config.overlayRect.top ) {
+                vPos='top';
+            }
+            else if ( mouseY + config.container.height / 2 > config.overlayRect.bottom ) {
+                vPos= 'bottom';
+            }
+        }
+    }
+    console.log('TooltipTrigger.getPosition(): vPos', vPos, 'hPos', hPos)
+    // if ( vPos === 'top' ) {
+    switch ( vPos ) {
+        case 'top':
+            top = mouseY + paddingTop ;
+            if(hPos === 'right') {
+                hPos = 'middle';
+            }
+            break;
+        case 'bottom':
+            top = mouseY - ( config.container.height + paddingTop );
+            if(hPos === 'right') {
+                hPos = 'middle';
+            }
+            break;
+        case 'middle':
+            // this is the default value... to set again.
+            // top = mouseY - ( config.container.height / 2 );
+            break;
+    }
+
+    switch(hPos) {
+        case 'left':
+            left = mouseX - ( config.container.width + paddingLeft );
+            break;
+        case 'right':
+            left = mouseX + paddingLeft;
+            break;
+        case 'middle':
+            left = mouseX - ( config.container.width / 2 ) ;
+            if (left < config.overlayRect.left) {
+                left = mouseX + paddingLeft;
+            } else if (left > config.overlayRect.right) {
+                left = mouseX - ( config.container.width + paddingLeft );
+            }
+            // console.log('TooltipTrigger.getPosition(): left', left, 'config', config)
+            break;
+    }
+
+    return [left, top];
+}
+
+export interface TooltipTriggerProps {
+    content: React.JSX.Element | string | undefined;
+    config: TooltipTriggerConfig | null;
+    open: boolean | undefined;
+
+    registerSetterSetTooltipContent: any
+    // registerSetterSetTooltipContent: (
+    //     (setter: React.JSX.Element | string) => void
+    // ) => void;
+
+    registerSetterSetTooltipOpen: (
+        setter: React.Dispatch<React.SetStateAction<boolean>>
+    ) => void;
+
+    registerSetterSetTooltipConfig: (
+        setter: React.Dispatch<React.SetStateAction<TooltipTriggerConfig>>
+    ) => void;
+    // onRefsChange?: ( refs: {
+    //     content: React.JSX.Element | string;
+    //     config: TooltipTriggerConfig;
+    // }) => void;
+}
+
+export type TooltipTriggerHandle = {
+    // setContainerDim: (w: number, h: number) => void;
+    setOverlayRect: (rect: DOMRect) => void;
+    setMousePosition: ( mouseX: number, mouseY: number) => void,
+    getTooltipContentRef: () => React.JSX.Element | string;
+    // getTooltipConfigRef: () => TooltipTriggerConfig;
+}
+
+export const TooltipTrigger = forwardRef<TooltipTriggerHandle, TooltipTriggerProps>((props, ref) => {
+    const [tooltipContent, setTooltipContent] = useState<React.JSX.Element | string>(props.content || 'Default Value');
+    const [tooltipOpen, setTooltipOpen] = useState<boolean>(props.open || false);
+    const [tooltipConfig, setTooltipConfig ] = useState<TooltipTriggerConfig>(props.config || {
+        x: 0,
+        y: 0,
+    });
+
+
+    const tooltipContentRef = useRef<string | React.JSX.Element>('Default Value');
+    const tooltipConfigRef = useRef<TooltipTriggerInternalConfig>({ 
+            x: props.config?.x || 0, 
+            y: props.config?.y || 0,
+            container: { width: 0, height: 0},
+            overlayRect: new DOMRect(0, 0, 0, 0),
+        });
+
+  const tooltipContainerRef = useRef<HTMLDivElement | null>(null);
+
+    // Expose setters to parent
+    const registerSetterSetTooltipContent = props.registerSetterSetTooltipContent;
+
+    useEffect( () => {
+        registerSetterSetTooltipContent( setTooltipContentWrapper() );
+    }, [registerSetterSetTooltipContent] );
+
+    const registerSetterSetTooltipOpen = props.registerSetterSetTooltipOpen;
+    useEffect( () => {
+        registerSetterSetTooltipOpen( setTooltipOpen );
+    }, [registerSetterSetTooltipOpen] );
+
+    const registerSetterSetTooltipConfig = props.registerSetterSetTooltipConfig;
+    useEffect( () => {
+        registerSetterSetTooltipConfig( setTooltipConfig );
+    }, [registerSetterSetTooltipConfig] );
+
+
+    function setTooltipContentWrapper( ){
+        return function( content: React.JSX.Element | string) {
+            // console.log("setTooltipContentWrapper: ici - typeof content: ", typeof content)
+            if (typeof content === "string") {
+                setTooltipContent( <div ref={tooltipContainerRef} dangerouslySetInnerHTML={{__html: content}}/> );
+            } else {
+                setTooltipContent( <div ref={tooltipContainerRef}>{content}</div> );
+            }
+        }
+    }
+
+    // set config and content ref
+    tooltipContentRef.current =
+        typeof tooltipContent === 'object'
+            ? tooltipContent.props?.dangerouslySetInnerHTML?.__html ?? ''
+            : tooltipContent;
+
+    useImperativeHandle(ref, () => ({
+
+        setOverlayRect(rect: DOMRect) {
+            if (tooltipConfigRef.current) {
+                tooltipConfigRef.current.overlayRect = rect;
+                // console.log('TooltipTrigger()/setOverlayRect: rect', rect);
+            }
+        },
+        setMousePosition( mouseX: number, mouseY: number) {
+            if (tooltipConfigRef.current) {
+                tooltipConfigRef.current.x = mouseX;
+                tooltipConfigRef.current.y = mouseY;
+                // console.log('TooltipTrigger()/setMousePosition(): (x,y)', [mouseX, mouseY]);
+                const [left, top] = getPosition(tooltipConfigRef.current);
+                const config:TooltipTriggerConfig = { 
+                    x: left,
+                    y: top,
+                }
+                setTooltipConfig(config)
+                setTooltipOpen(true);
+            }
+
+        },
+        getTooltipContentRef() {
+            return tooltipContentRef?.current;
+        },
+    }));
+
+    useEffect( () => {
+        if (!tooltipConfigRef.current) {
+            return;
+        }
+        tooltipConfigRef.current.x = tooltipConfig.x;
+        tooltipConfigRef.current.y = tooltipConfig.y;
+        // console.log('TooltipTrigger(/useEffect(tooltipConfig)): src tooltipConfig:', tooltipConfig, 'dst tooltipConfigRef', tooltipConfigRef.current)
+    }, [tooltipConfig]);
+
+    // useEffect( () => {
+    //     if (tooltipOpen && tooltipContainerRef && tooltipContainerRef.current) {
+
+    //         // console.log('TooltipTrigger.useEffect(/tooltipOpen): setContainerDim candidate:', tooltipContainerRef.current);
+    //         const containerRect = tooltipContainerRef.current.getBoundingClientRect() ?? new DOMRect(0, 0, 0, 0);
+    //         if (tooltipConfigRef.current) {
+    //             tooltipConfigRef.current.container.width = containerRect.width;
+    //             tooltipConfigRef.current.container.height = containerRect.height;
+    //             console.log('TooltipTrigger.useEffect(/tooltipOpen): setContainerDim (w,h):', [containerRect.width, containerRect.height]);
+    //         }
+
+    //     }
+    // }, [tooltipOpen, tooltipContent]);
+
+    useEffect( () => {
+        if (tooltipOpen && tooltipContainerRef && tooltipContainerRef.current) {
+
+            // console.log('TooltipTrigger.useEffect(/tooltipOpen): setContainerDim candidate:', tooltipContainerRef.current);
+            const containerRect = tooltipContainerRef.current.getBoundingClientRect() ?? new DOMRect(0, 0, 0, 0);
+            if (tooltipConfigRef.current) {
+                tooltipConfigRef.current.container.width = containerRect.width;
+                tooltipConfigRef.current.container.height = containerRect.height;
+//                console.log('TooltipTrigger.useEffect(/tooltipOpen): setContainerDim (w,h):', [containerRect.width, containerRect.height]);
+            }
+
+        }
+    }, [tooltipOpen, tooltipContainerRef.current]);
+
+    //------
+    
+    const styles = useStyles2(getStyles);
+
+    let content;
+    if (typeof tooltipContent !== "string") {
+        // console.log("build TooltipTrigger(): tooltipConfig", tooltipConfig)
+        content = (
+            <div ref={tooltipContainerRef}
+                className={cx(
+                    styles.wrapper,
+                    css`
+                    max-width: ${props.config?.maxWidth ? props.config.maxWidth + 'px' : '800px'};
+                    max-height: ${props.config?.maxHeight ? props.config.maxHeight + 'px' : '600px'};
+                    overflow: auto;
+                    `
+                    )}>
+                {tooltipContent}
+            </div>
+        );
+    } else {
+        content = <div
+            className={cx(
+                styles.wrapper,
+                css`
+                    max-width: ${props.config?.maxWidth ? props.config.maxWidth + 'px' : '800px'};
+                    max-height: ${props.config?.maxHeight ? props.config.maxHeight + 'px' : '600px'};
+                    overflow: auto;
+                    `
+                )}
+            ref={tooltipContainerRef}
+            dangerouslySetInnerHTML={{__html: tooltipContent}}
+        />
+    }
+
+    return (
+        <Popover
+            show={tooltipOpen}
+            referenceElement={{
+                getBoundingClientRect: () => new DOMRect(tooltipConfig.x, tooltipConfig.y, 0, 0),
+            }}
+            content={content}
+        />
+    );
+});
+
+const getStyles = (theme: GrafanaTheme2) => {
+    return {
+        wrapper: css({
+            background: theme.components.tooltip.background,
+            border: `1px solid ${theme.colors.border.weak}`, 
+            borderRadius: theme.shape.radius.default,
+            boxShadow: theme.shadows.z2,
+            fontSize: theme.typography.bodySmall.fontSize,
+            left: 0,
+            top: 0,
+            maxWidth: '800px',
+            maxHeight: '600px',
+            overflow: 'auto',
+            padding: theme.spacing(1),
+            position: 'fixed',
+            userSelect: 'text',
+            whiteSpace: 'pre',
+            zIndex: theme.zIndex.tooltip,
+        }),
+ 
+    };
+};
+
+TooltipTrigger.displayName = 'TooltipTrigger';

--- a/src/components/bespokeDriver.tsx
+++ b/src/components/bespokeDriver.tsx
@@ -1,5 +1,5 @@
 import { DatapointMode, PanelConfigCell } from 'components/Config';
-import { BespokeStateHolder, getCellValue} from './SvgUpdater';
+import { BespokeStateHolder, getCellValue, GetCellValueType} from './SvgUpdater';
 import { MathNode, parse } from 'mathjs'
 import { TimeSeriesData } from './TimeSeries';
 import { getTemplateSrv } from '@grafana/runtime';
@@ -18,6 +18,9 @@ type Utils = {
 type NamespacedData =  {
   utils: Utils;
   data: any;
+  labels: any;
+  aggregations: any;
+  data_ts: any;
   // plus client defined variables
 };
 
@@ -170,9 +173,13 @@ function grafanaVariablesReplace(str: string) {
   return getTemplateSrv().replace(str);
 }
 
+function convertToNumber(str: string) {
+  return Number(str)
+}
 function clientExposedUtils(highlighterSelection: string) {
   return {
     log: flowDebug().info,
+    "Number": convertToNumber,
     variablesReplace: grafanaVariablesReplace,
     highlighterSelection: highlighterSelection,
     highlighterState: 'Ambient',
@@ -181,6 +188,8 @@ function clientExposedUtils(highlighterSelection: string) {
 
 export function attribDriverManager(cbh: CellBespokeHandler[], tsData: TimeSeriesData, highlighterSelection: string | undefined) {
   const namespacedData  = new Map<string, NamespacedData>();
+  let current_ts = 0;
+  let count_ts = 0 ;
 
   // Initialize each namespaced store with constants and data
   cbh.forEach((handler: CellBespokeHandler) => {
@@ -191,6 +200,8 @@ export function attribDriverManager(cbh: CellBespokeHandler[], tsData: TimeSerie
       const vars = Object.fromEntries([
         ['utils', clientExposedUtils(highlighterSelection || '')],
         ['data', {}],
+        ['labels', {}],
+        ['aggregations', {}],
         ...handler.clientState.constants]);
       namespacedData.set(namespace, vars);
     }
@@ -202,10 +213,19 @@ export function attribDriverManager(cbh: CellBespokeHandler[], tsData: TimeSerie
       if (typeof dataStore.data[dataRef] === 'undefined') {
         const drive = {dataRef: dataRef, bespokeDataRef: undefined, datapoint: bespokeDataDatapoint};
         const dataValue = getCellValue(drive, tsData, null);
-        dataStore.data[dataRef] = dataValue;
+        dataStore.data[dataRef] = dataValue.value;
+        dataStore.labels[dataRef] = dataValue.labels ? Object.fromEntries(dataValue.labels) : new Object;
+        dataStore.aggregations[dataRef] = dataValue.aggregations ? Object.fromEntries(dataValue.aggregations) : new Object;
+        // const data = { 'value': dataValue.value, 'labels': dataValue.labels, 'aggregations': dataValue.aggregations }
+        // dataStore.data[dataRef] = data;
+        current_ts += dataValue.ts;
+        count_ts ++;
       }
     });
   });
+  // set an average ts value 
+  current_ts = Math.round(current_ts/count_ts);
+
 
   // Invoke the formulas
   const namespaceUpdated = new Set<string>();
@@ -243,6 +263,19 @@ export function attribDriverManager(cbh: CellBespokeHandler[], tsData: TimeSerie
     }
     catch (err) {
       flowDebug().warn('Error occurred calculating bespoke attribute for', handler.element, 'error =', err);
+    }
+  });
+
+  // set the bespoke values in attended format (GetCellValueType)
+  cbh.forEach((handler: CellBespokeHandler) => {
+    const namespace = handler.clientState.namespace;
+    const dataStore = namespacedData.get(namespace) as NamespacedData;
+    for (const [k, v] of Object.entries(dataStore)) {
+      if ( !['data', 'utils'].includes(k) && ( typeof v === "number" || typeof v === "string" ) ) {
+        const obj = dataStore as any;
+        const value: GetCellValueType = {"value": v, "ts": current_ts, "labels": null, "aggregations": null}
+        obj[k] = value;
+      }
     }
   });
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -41,6 +41,7 @@ export const plugin = new PanelPlugin<FlowOptions>(FlowPanel).setPanelOptions((b
   .addBooleanSwitch({
     path: 'panZoomEnabled',
     name: 'Pan / Zoom Enabled',
+    category: ['Options'],
     description: `When enabled the scroll wheel allows you to zoom and click-drag allows
     you to pan. Double-Click to reset zoom to normal. Note the scroll wheel can be configured
     to need additional keys such as 'Alt' to separate panel zoom from dashboard scroll. Check
@@ -50,6 +51,7 @@ export const plugin = new PanelPlugin<FlowOptions>(FlowPanel).setPanelOptions((b
   .addBooleanSwitch({
     path: 'animationsEnabled',
     name: 'Animations Enabled',
+    category: ['Options'],
     description: `This defines the initial state of animations controlled via yaml data. The actual
     state is dynamically settable from the play/pause button in the bottom left corner of the
     panel. The button is only visible if animations have been defined in the yaml data.`,
@@ -58,6 +60,7 @@ export const plugin = new PanelPlugin<FlowOptions>(FlowPanel).setPanelOptions((b
   .addBooleanSwitch({
     path: 'animationControlEnabled',
     name: 'Animation Control Enabled',
+    category: ['Options'],
     description: `This defines whether the pause/play animation control is shown in the
     bottom left corner of the panel. The button is only visible if animations have also been
     defined in the yaml data.`,
@@ -66,6 +69,7 @@ export const plugin = new PanelPlugin<FlowOptions>(FlowPanel).setPanelOptions((b
   .addBooleanSwitch({
     path: 'highlighterEnabled',
     name: 'Highlighter',
+    category: ['Options'],
     description: `When enabled a highlighting bar is added below the SVG. Widgets on the
     SVG have optional tags defined in the yaml and the highlighter allows you to bring
     a thread of information to the front.`,
@@ -74,12 +78,14 @@ export const plugin = new PanelPlugin<FlowOptions>(FlowPanel).setPanelOptions((b
   .addTextInput({
     path: 'highlighterSelection',
     name: 'Highlighter Selection',
+    category: ['Options'],
     description: `The initial highlighter tag selection. If empty it will default to the panelConfig value.`,
     defaultValue: '',
   })
   .addBooleanSwitch({
     path: 'timeSliderEnabled',
     name: 'Time Slider',
+    category: ['Options'],
     description: `When selected a time-slider is added to the bottom of
     the panel to support visualization of any time point in the time range.
     Even when not selected the panel can still respond to other panels time-sliders
@@ -89,6 +95,7 @@ export const plugin = new PanelPlugin<FlowOptions>(FlowPanel).setPanelOptions((b
   .addRadio({
     path: 'timeSliderMode',
     name: 'Time Slider Mode',
+    category: ['Options'],
     description: `This defines how the time-slider will respond to the dashboard
     environment. 'Local' means the time-slider is isolated from other panels.
     'Time' means it will synchronize with the time value of other time-sliders or
@@ -108,9 +115,19 @@ export const plugin = new PanelPlugin<FlowOptions>(FlowPanel).setPanelOptions((b
   .addBooleanSwitch({
     path: 'testDataEnabled',
     name: 'Test Data Generation',
+    category: ['Options'],
     description: `This enriches the grafana time series with additional test-data series that
     are used in the demonstration SVGs. It adds runtime overhead so only enable when getting
     started.`,
+    defaultValue: true,
+  })
+  .addBooleanSwitch({
+    path: 'seriesAggregation',
+    name: 'Compute Series Aggregations',
+    category: ['Options'],
+    description: `This enriches the grafana time series with additional aggregations that
+    can be used in dataRef or formulas via aggregations array (like data[] or labels[]). It adds runtime overhead so
+    only enable when required.`,
     defaultValue: true,
   })
   .addCustomEditor({

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,4 +21,5 @@ export interface FlowOptions {
   timeSliderMode: TimeSliderMode;
   debuggingCtr: DebuggingCtrs;
   testDataEnabled: boolean;
+  seriesAggregation: boolean;
 };


### PR DESCRIPTION
Several improvements:

- Added label data for time series, accessible via `labels["ts_name"].key_label` as in `data["ts_name"]`, where `key_label` is the name of the label. For example: `labels["test-data-small-sin"].label1`

- Added aggregation data (min, max, mean, last, etc.) accessible via `aggregations["ts_name"].aggr`: e.g., `aggregations["test-data-small-sin"].min`

- Added tooltips, in which:

  - An HTML display format can be defined containing variables to be displayed.

  - The definition of variables, their values, a label, and a label color, as for a cell.

- Added a function `utils.Number(strNum)` to convert a string containing a number; useful if you have a label containing a numerical value that you want to display in Grafana units.

- Provided an example dashboard for manipulating tooltips.

No documentation is available at the moment; we'll see based on feedback on the pull request.

example:

```yaml
cells: 
  box1:
    bespoke:
      dataRefs:
        - "test-data-small-sin"
        - "test-data-large-cos"
# pmr #190: constants not read if drive is not defined.
#      constants: 
#        sinRef: test-data-small-sin
#        cosRef: test-data-large-cos
      formulas:
        - 'curCos = data["test-data-large-cos"]'
        - 'curSin = data["test-data-large-sin"]'
        - 'strNum= "42"'
        - "num = utils.Number(strNum) + 1"
    dataRef: "test-data-large-sin"
    bespokeDataRef: curCos
    label: 
      separator: "cr"
      units: "none"
      decimalPoints: 0
    labelColor:
      gradientMode: "normal"
      thresholds: *threshold_three_status
    tooltips:
      format: |-
        <center>$labelSin</center><br>
        <span style="background-color: $current.labelColor;">value: $current.label</span><br>
        <span>value: $sin</span><br><span>ts: $sin.ts</span>
      elements:
        sin:
          label:
            bespokeDataRef: curSin
            units: "none"
            decimalPoints: 0
          labelColor:
            gradientMode: "normal"
            thresholds: *threshold_three_status
        labelSin:
          label:
            bespokeDataRef: num
            units: "none"
```

https://github.com/user-attachments/assets/7e735f51-d404-4b81-b59a-7345ca1aa639

